### PR TITLE
Add logging for Unity messages and fix assembly dumping

### DIFF
--- a/BepInEx/Bootstrap/Chainloader.cs
+++ b/BepInEx/Bootstrap/Chainloader.cs
@@ -52,6 +52,9 @@ namespace BepInEx.Bootstrap
 
                 Logger.SetLogger(unityLogWriter);
 
+                if(bool.Parse(Config.GetEntry("log_unity_messages", "false", "Global")))
+                    UnityLogWriter.ListenUnityLogs();
+
 			    string consoleTile = $"BepInEx {Assembly.GetExecutingAssembly().GetName().Version} - {Application.productName}";
 			    ConsoleWindow.Title = consoleTile;
                 

--- a/BepInEx/Logging/UnityLogWriter.cs
+++ b/BepInEx/Logging/UnityLogWriter.cs
@@ -49,15 +49,15 @@ namespace BepInEx.Logging
         {
             Type application = typeof(Application);
 
-            MethodInfo registerLogCallback = application.GetMethod("RegisterLogCallback", BindingFlags.Public | BindingFlags.Static);
-            if (registerLogCallback != null)
+            EventInfo logEvent = application.GetEvent("logMessageReceived", BindingFlags.Public | BindingFlags.Static);
+            if (logEvent != null)
             {
-                registerLogCallback.Invoke(null, new object[] {new Application.LogCallback(OnUnityLogMessageReceived)});
+                logEvent.AddEventHandler(null, new Application.LogCallback(OnUnityLogMessageReceived));
             }
             else
             {
-                EventInfo logEvent = application.GetEvent("logMessageReceived", BindingFlags.Public | BindingFlags.Static);
-                logEvent?.AddEventHandler(null, new Application.LogCallback(OnUnityLogMessageReceived));
+                MethodInfo registerLogCallback = application.GetMethod("RegisterLogCallback", BindingFlags.Public | BindingFlags.Static);
+                registerLogCallback.Invoke(null, new object[] { new Application.LogCallback(OnUnityLogMessageReceived) });
             }
         }
 


### PR DESCRIPTION
* Add opt-in logging for Unity messages via `log_unity_messages` configuration option
* Fix assembly dumping to only dump patched assemblies