### PR TITLE
Mark unity Log messages as Info instead of Message

### DIFF
--- a/BepInEx/Logging/UnityLogWriter.cs
+++ b/BepInEx/Logging/UnityLogWriter.cs
@@ -77,7 +77,7 @@ namespace BepInEx.Logging
                     break;
                 case LogType.Log:
                 default:
-                    logLevel = LogLevel.Message;
+                    logLevel = LogLevel.Info;
                     break;
             }
 


### PR DESCRIPTION
Prevents unnecessary message popups in interface.