### PR TITLE
Fix multiclass preloader patch

### DIFF
--- a/BepInEx/Bootstrap/Preloader.cs
+++ b/BepInEx/Bootstrap/Preloader.cs
@@ -86,8 +86,8 @@ namespace BepInEx.Bootstrap
 						{
 							var assembly = Assembly.LoadFrom(assemblyPath);
 
-							foreach (KeyValuePair<AssemblyPatcherDelegate, IEnumerable<string>> kv in GetPatcherMethods(assembly))
-								sortedPatchers.Add(assembly.GetName().Name, kv);
+							foreach (KeyValuePair<string, KeyValuePair<AssemblyPatcherDelegate, IEnumerable<string>>> kv in GetPatcherMethods(assembly))
+								sortedPatchers.Add(kv.Key, kv.Value);
 						}
 						catch (BadImageFormatException) { } //unmanaged DLL
 						catch (ReflectionTypeLoadException) { } //invalid references
@@ -129,9 +129,9 @@ namespace BepInEx.Bootstrap
 		/// </summary>
 		/// <param name="assembly">The assembly to scan.</param>
 		/// <returns>A dictionary of delegates which will be used to patch the targeted assemblies.</returns>
-		public static Dictionary<AssemblyPatcherDelegate, IEnumerable<string>> GetPatcherMethods(Assembly assembly)
+		public static Dictionary<string, KeyValuePair<AssemblyPatcherDelegate, IEnumerable<string>>> GetPatcherMethods(Assembly assembly)
 		{
-			var patcherMethods = new Dictionary<AssemblyPatcherDelegate, IEnumerable<string>>();
+			var patcherMethods = new Dictionary<string, KeyValuePair<AssemblyPatcherDelegate, IEnumerable<string>>>();
 
 			foreach (var type in assembly.GetExportedTypes())
 				try
@@ -177,7 +177,7 @@ namespace BepInEx.Bootstrap
 
 					var targets = (IEnumerable<string>) targetsProperty.GetValue(null, null);
 
-					patcherMethods[patchDelegate] = targets;
+					patcherMethods[$"{assembly.GetName().Name}{type.FullName}"] = new KeyValuePair<AssemblyPatcherDelegate, IEnumerable<string>>(patchDelegate, targets);
 
 					var initMethod = type.GetMethod("Initialize",
 						BindingFlags.Public | BindingFlags.Static | BindingFlags.IgnoreCase,

--- a/BepInEx/Bootstrap/Preloader.cs
+++ b/BepInEx/Bootstrap/Preloader.cs
@@ -87,7 +87,14 @@ namespace BepInEx.Bootstrap
 							var assembly = Assembly.LoadFrom(assemblyPath);
 
 							foreach (KeyValuePair<string, KeyValuePair<AssemblyPatcherDelegate, IEnumerable<string>>> kv in GetPatcherMethods(assembly))
-								sortedPatchers.Add(kv.Key, kv.Value);
+							    try
+							    {
+							        sortedPatchers.Add(kv.Key, kv.Value);
+							    }
+							    catch (ArgumentException)
+							    {
+                                    Logger.Log(LogLevel.Warning, $"Found duplicate of patcher {kv.Key}!");
+							    }
 						}
 						catch (BadImageFormatException) { } //unmanaged DLL
 						catch (ReflectionTypeLoadException) { } //invalid references


### PR DESCRIPTION
Fixes issue reported in #51.
Fixed by sorting assembly patchers by a combination of assembly name and type name instead of just assembly name.

On a side note: we might need to consider introducing a custom patcher type (like in [feature-appdomain-patcher](/BepInEx/BepInEx/tree/feature-appdomain-patcher)) to get rid of the confusing `KeyValuePair<T, S>` mess.