### PR TITLE
Display all log levels in output_log.txt

### DIFF
--- a/BepInEx/Logging/UnityLogWriter.cs
+++ b/BepInEx/Logging/UnityLogWriter.cs
@@ -36,6 +36,10 @@ namespace BepInEx.Logging
             Kon.ForegroundColor = level.GetConsoleColor();
             base.Log(level, entry);
             Kon.ForegroundColor = ConsoleColor.Gray;
+
+            // If the display level got ignored, still write it to the log
+            if ((DisplayedLevels & level) == LogLevel.None)
+                WriteToLog($"[{level.GetHighestLevel()}] {entry}\r\n");
         }
 
         public override void WriteLine(string value) => InternalWrite($"{value}\r\n");


### PR DESCRIPTION
Implement suggestion in #53 by explicitly writing to Unity log when the log level is too low.