### PR TITLE
 Added MinimumVersion support to BepInDependency and added BepInIncompatibility

### DIFF
--- a/BepInEx/Bootstrap/Chainloader.cs
+++ b/BepInEx/Bootstrap/Chainloader.cs
@@ -272,7 +272,8 @@ namespace BepInEx.Bootstrap
 					{
 						string ToMissingString(BepInDependency s)
 						{
-							if (s.MinimumVersion.IsZero()) return "- " + s.DependencyGUID;
+							bool emptyVersion = s.MinimumVersion.Major == 0 && s.MinimumVersion.Minor == 0 && s.MinimumVersion.Build == 0 && s.MinimumVersion.Revision == 0;
+							if (emptyVersion) return "- " + s.DependencyGUID;
 							return $"- {s.DependencyGUID} (at least v{s.MinimumVersion})";
 						}
 

--- a/BepInEx/Bootstrap/Chainloader.cs
+++ b/BepInEx/Bootstrap/Chainloader.cs
@@ -27,6 +27,8 @@ namespace BepInEx.Bootstrap
 
 		public static List<BaseUnityPlugin> Plugins { get; } = new List<BaseUnityPlugin>();
 
+		public static List<string> DependencyErrors { get; } = new List<string>();
+
 		/// <summary>
 		/// The GameObject that all plugins are attached to as components.
 		/// </summary>
@@ -255,7 +257,9 @@ namespace BepInEx.Bootstrap
 
 					if (dependsOnInvalidPlugin)
 					{
-						Logger.LogWarning($"Skipping [{pluginInfo.Metadata.Name}] because it has a dependency that was not loaded. See above errors for details.");
+						string message = $"Skipping [{pluginInfo.Metadata.Name}] because it has a dependency that was not loaded. See above errors for details.";
+						DependencyErrors.Add(message);
+						Logger.LogWarning(message);
 						continue;
 					}
 
@@ -267,9 +271,11 @@ namespace BepInEx.Bootstrap
 							return $"- {s.DependencyGUID} (at least v{s.MinimumVersion})";
 						}
 
-						Logger.LogError($@"Missing the following dependencies for [{pluginInfo.Metadata.Name}]: {"\r\n"}{
+						string message = $@"Missing the following dependencies for [{pluginInfo.Metadata.Name}]: {"\r\n"}{
 								string.Join("\r\n", missingDependencies.Select(ToMissingString).ToArray())
-							}{"\r\n"}Loading will be skipped; expect further errors and unstabilities.");
+							}{"\r\n"}Loading will be skipped; expect further errors and unstabilities.";
+						DependencyErrors.Add(message);
+						Logger.LogError(message);
 
 						invalidPlugins.Add(pluginGUID);
 						continue;

--- a/BepInEx/Bootstrap/Chainloader.cs
+++ b/BepInEx/Bootstrap/Chainloader.cs
@@ -276,9 +276,7 @@ namespace BepInEx.Bootstrap
 							return $"- {s.DependencyGUID} (at least v{s.MinimumVersion})";
 						}
 
-						string message = $@"Missing the following dependencies for [{pluginInfo.Metadata.Name}]: {"\r\n"}{
-								string.Join("\r\n", missingDependencies.Select(ToMissingString).ToArray())
-							}{"\r\n"}Loading will be skipped; expect further errors and unstabilities.";
+						string message = $@"Could not load [{pluginInfo.Metadata.Name}] because it has missing dependencies: {string.Join(", ", missingDependencies.Select(ToMissingString).ToArray())}";
 						DependencyErrors.Add(message);
 						Logger.LogError(message);
 
@@ -288,9 +286,7 @@ namespace BepInEx.Bootstrap
 
 					if (incompatibilities.Count != 0)
 					{
-						string message = $@"Found incompatible plugins for [{pluginInfo.Metadata.Name}]: {"\r\n"}{
-								string.Join("\r\n", incompatibilities.Select(i => i.IncompatibilityGUID).ToArray())
-							}{"\r\n"}Loading will be skipped; expect further errors and unstabilities.";
+						string message = $@"Could not load [{pluginInfo.Metadata.Name}] because it is incompatible with: {string.Join(", ", incompatibilities.Select(i => i.IncompatibilityGUID).ToArray())}";
 						DependencyErrors.Add(message);
 						Logger.LogError(message);
 

--- a/BepInEx/Contract/PluginInfo.cs
+++ b/BepInEx/Contract/PluginInfo.cs
@@ -13,6 +13,8 @@ namespace BepInEx.Contract
 
 		public IEnumerable<BepInDependency> Dependencies { get; internal set; }
 
+		public IEnumerable<BepInIncompatibility> Incompatibilities { get; set; }
+
 		public string Location { get; internal set; }
 
 		public BaseUnityPlugin Instance { get; internal set; }
@@ -36,6 +38,11 @@ namespace BepInEx.Contract
 			bw.Write(depList.Count);
 			foreach (var bepInDependency in depList)
 				((ICacheable)bepInDependency).Save(bw);
+
+			var incList = Incompatibilities.ToList();
+			bw.Write(incList.Count);
+			foreach (var bepInIncompatibility in incList)
+				((ICacheable)bepInIncompatibility).Save(bw);
 		}
 
 		void ICacheable.Load(BinaryReader br)
@@ -60,6 +67,17 @@ namespace BepInEx.Contract
 			}
 
 			Dependencies = depList;
+
+			var incCount = br.ReadInt32();
+			var incList = new List<BepInIncompatibility>(incCount);
+			for (int i = 0; i < incCount; i++)
+			{
+				var inc = new BepInIncompatibility("");
+				((ICacheable)inc).Load(br);
+				incList.Add(inc);
+			}
+
+			Incompatibilities = incList;
 		}
 	}
 }

--- a/BepInEx/Contract/PluginInfo.cs
+++ b/BepInEx/Contract/PluginInfo.cs
@@ -38,6 +38,7 @@ namespace BepInEx.Contract
 			{
 				bw.Write(bepInDependency.DependencyGUID);
 				bw.Write((int)bepInDependency.Flags);
+				bw.Write(bepInDependency.MinimumVersion.ToString());
 			}
 		}
 
@@ -56,7 +57,7 @@ namespace BepInEx.Contract
 			var depCount = br.ReadInt32();
 			var depList = new List<BepInDependency>(depCount);
 			for (int i = 0; i < depCount; i++)
-				depList.Add(new BepInDependency(br.ReadString(), (BepInDependency.DependencyFlags) br.ReadInt32()));
+				depList.Add(new BepInDependency(br.ReadString(), (BepInDependency.DependencyFlags) br.ReadInt32(), br.ReadString()));
 			Dependencies = depList;
 		}
 	}

--- a/BepInEx/Contract/PluginInfo.cs
+++ b/BepInEx/Contract/PluginInfo.cs
@@ -19,7 +19,7 @@ namespace BepInEx.Contract
 
 		internal string TypeName { get; set; }
 
-		public void Save(BinaryWriter bw)
+		void ICacheable.Save(BinaryWriter bw)
 		{
 			bw.Write(TypeName);
 
@@ -35,14 +35,10 @@ namespace BepInEx.Contract
 			var depList = Dependencies.ToList();
 			bw.Write(depList.Count);
 			foreach (var bepInDependency in depList)
-			{
-				bw.Write(bepInDependency.DependencyGUID);
-				bw.Write((int)bepInDependency.Flags);
-				bw.Write(bepInDependency.MinimumVersion.ToString());
-			}
+				((ICacheable)bepInDependency).Save(bw);
 		}
 
-		public void Load(BinaryReader br)
+		void ICacheable.Load(BinaryReader br)
 		{
 			TypeName = br.ReadString();
 
@@ -57,7 +53,12 @@ namespace BepInEx.Contract
 			var depCount = br.ReadInt32();
 			var depList = new List<BepInDependency>(depCount);
 			for (int i = 0; i < depCount; i++)
-				depList.Add(new BepInDependency(br.ReadString(), (BepInDependency.DependencyFlags) br.ReadInt32(), br.ReadString()));
+			{
+				var dep = new BepInDependency("");
+				((ICacheable)dep).Load(br);
+				depList.Add(dep);
+			}
+
 			Dependencies = depList;
 		}
 	}

--- a/BepInEx/Contract/PluginInfo.cs
+++ b/BepInEx/Contract/PluginInfo.cs
@@ -13,7 +13,7 @@ namespace BepInEx.Contract
 
 		public IEnumerable<BepInDependency> Dependencies { get; internal set; }
 
-		public IEnumerable<BepInIncompatibility> Incompatibilities { get; set; }
+		public IEnumerable<BepInIncompatibility> Incompatibilities { get; internal set; }
 
 		public string Location { get; internal set; }
 

--- a/BepInEx/Utility.cs
+++ b/BepInEx/Utility.cs
@@ -237,5 +237,10 @@ namespace BepInEx
 				return false;
 			}
 		}
+
+		internal static bool IsZero(this Version v)
+		{
+			return v.Major == 0 && v.Minor == 0 && v.Build == 0 && v.Revision == 0;
+		}
 	}
 }

--- a/BepInEx/Utility.cs
+++ b/BepInEx/Utility.cs
@@ -237,10 +237,5 @@ namespace BepInEx
 				return false;
 			}
 		}
-
-		internal static bool IsZero(this Version v)
-		{
-			return v.Major == 0 && v.Minor == 0 && v.Build == 0 && v.Revision == 0;
-		}
 	}
 }


### PR DESCRIPTION
Plugins can require a minimum version of another plugin. 
Exposed DependencyErrors is for displaying ton screen in MessageCenter so average user can see something is wrong.