### PR TITLE
Allow Console to fail gracefully if missing extern

### DIFF
--- a/BepInEx/ConsoleUtil/Kon.cs
+++ b/BepInEx/ConsoleUtil/Kon.cs
@@ -64,20 +64,28 @@ namespace BepInEx.ConsoleUtil
 			succeeded = false;
 			if (!(conOut == INVALID_HANDLE_VALUE))
 			{
-				CONSOLE_SCREEN_BUFFER_INFO console_SCREEN_BUFFER_INFO;
-				if (!GetConsoleScreenBufferInfo(conOut, out console_SCREEN_BUFFER_INFO))
+				try
 				{
-					bool consoleScreenBufferInfo = GetConsoleScreenBufferInfo(GetStdHandle(-12), out console_SCREEN_BUFFER_INFO);
-					if (!consoleScreenBufferInfo)
-						consoleScreenBufferInfo = GetConsoleScreenBufferInfo(GetStdHandle(-10), out console_SCREEN_BUFFER_INFO);
-
-					if (!consoleScreenBufferInfo)
-						if (Marshal.GetLastWin32Error() == 6 && !throwOnNoConsole)
-							return default(CONSOLE_SCREEN_BUFFER_INFO);
+					// FIXME: Windows console shouldn't be used in other OSs in the first place
+					CONSOLE_SCREEN_BUFFER_INFO console_SCREEN_BUFFER_INFO;
+					if (!GetConsoleScreenBufferInfo(conOut, out console_SCREEN_BUFFER_INFO))
+					{
+						bool consoleScreenBufferInfo = GetConsoleScreenBufferInfo(GetStdHandle(-12), out console_SCREEN_BUFFER_INFO);
+						if (!consoleScreenBufferInfo)
+							consoleScreenBufferInfo = GetConsoleScreenBufferInfo(GetStdHandle(-10), out console_SCREEN_BUFFER_INFO);
+						
+						if (!consoleScreenBufferInfo)
+							if (Marshal.GetLastWin32Error() == 6 && !throwOnNoConsole)
+								return default(CONSOLE_SCREEN_BUFFER_INFO);
+							
+							succeeded = true;
+						return console_SCREEN_BUFFER_INFO;
+					}
 				}
-
-				succeeded = true;
-				return console_SCREEN_BUFFER_INFO;
+				catch (EntryPointNotFoundException)
+				{
+					// Fails under unsupported OSes
+				}
 			}
 
 			if (!throwOnNoConsole)


### PR DESCRIPTION
Currently, BepInEx fails to run under Linux/OSX due to the missing externs. It crashes whenever Console is called.

This small change allows Linux/OSX to be able to run BepInEx without issues by disabling the Console.

This is a bandaid to the problem, Console is only supported under
Windows OS.