### PR TITLE
Limit line.Split in ConfigFile.Reload()

### DIFF
--- a/BepInEx/Configuration/ConfigFile.cs
+++ b/BepInEx/Configuration/ConfigFile.cs
@@ -118,7 +118,7 @@ namespace BepInEx.Configuration
 						continue;
 					}
 
-					string[] split = line.Split('='); //actual config line
+					string[] split = line.Split(new [] { '=' }, 2); //actual config line
 					if (split.Length != 2)
 						continue; //empty/invalid line
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
Limiting the line.Split in Reload() to 2 substrings to allow for values containing `=` characters. Original functionality is maintained.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I stumbled across this bug when trying to use `=` characters in my config values.  
I see no reason config values shouldn't be allowed to contain `=`'s, I assume this was an oversight when originally implemented. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This is such a small, basic change that I have not tested it but if absolutely necessary I can test it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
