### PR TITLE
Fix "wrong version of BepInEx" warning caused by dll split in v6

### DIFF
--- a/BepInEx.Core/Bootstrap/BaseChainloader.cs
+++ b/BepInEx.Core/Bootstrap/BaseChainloader.cs
@@ -288,7 +288,7 @@ namespace BepInEx.Bootstrap
 			var dependencies = BepInDependency.FromCecilType(type);
 			var incompatibilities = BepInIncompatibility.FromCecilType(type);
 
-			var bepinVersion = type.Module.AssemblyReferences.FirstOrDefault(reference => reference.Name == "BepInEx")?.Version ?? new Version();
+			var bepinVersion = type.Module.AssemblyReferences.FirstOrDefault(reference => reference.Name == "BepInEx.Core")?.Version ?? new Version();
 
 			return new PluginInfo
 			{


### PR DESCRIPTION
Stops
https://github.com/BepInEx/BepInEx/blob/5bababd7a3158f63f94c57d3fb712f05c2d621bd/BepInEx.Core/Bootstrap/BaseChainloader.cs#L127-L129
from appearing everytime.