### PR TITLE
Automatic plugin info from assembly attributes

### DIFF
--- a/BepInEx.Core/Contract/Attributes.cs
+++ b/BepInEx.Core/Contract/Attributes.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using BepInEx.Bootstrap;
 using Mono.Cecil;
+using MonoMod.Utils;
 using Version = SemVer.Version;
 using Range = SemVer.Range;
 
@@ -21,7 +22,7 @@ namespace BepInEx
         /// <param name="GUID">The unique identifier of the plugin. Should not change between plugin versions.</param>
         /// <param name="Name">The user friendly name of the plugin. Is able to be changed between versions.</param>
         /// <param name="Version">The specific version of the plugin.</param>
-        public BepInPlugin(string GUID, string Name, string Version)
+        public BepInPlugin(string GUID, string Name = null, string Version = null)
         {
             this.GUID = GUID;
             this.Name = Name;
@@ -70,9 +71,67 @@ namespace BepInEx
             if (attr == null)
                 return null;
 
-            return new BepInPlugin((string) attr.ConstructorArguments[0].Value,
-                                   (string) attr.ConstructorArguments[1].Value,
-                                   (string) attr.ConstructorArguments[2].Value);
+            var guid = (string) attr.ConstructorArguments[0].Value;
+            var name = (string) attr.ConstructorArguments[1].Value;
+            var version = (string) attr.ConstructorArguments[2].Value;
+
+            var assembly = td.Module.Assembly;
+
+            if (name == null)
+            {
+                name = assembly.Name.Name;
+
+                var nameAttribute = assembly.GetCustomAttribute(typeof(AssemblyTitleAttribute).FullName);
+                if (nameAttribute != null && nameAttribute.ConstructorArguments.Count == 1)
+                {
+                    name = (string) nameAttribute.ConstructorArguments.Single().Value;
+                }
+            }
+
+            if (version == null)
+            {
+                version = assembly.Name.Version.ToString();
+
+                var versionAttribute = assembly.GetCustomAttribute(typeof(AssemblyInformationalVersionAttribute).FullName);
+                if (versionAttribute != null && versionAttribute.ConstructorArguments.Count == 1)
+                {
+                    version = (string) versionAttribute.ConstructorArguments.Single().Value;
+                }
+            }
+
+            return new BepInPlugin(guid, name, version);
+        }
+
+        internal void Update(Type pluginType)
+        {
+            var assembly = pluginType.Assembly;
+
+            if (Name == null)
+            {
+                Name = assembly.GetName().Name;
+
+                var nameAttribute = MetadataHelper.GetAttributes<AssemblyTitleAttribute>(assembly).Single();
+                if (nameAttribute != null)
+                {
+                    Name = nameAttribute.Title;
+                }
+            }
+
+            if (Version == null)
+            {
+                var version = assembly.GetName().Version;
+                Version = new Version(version.Major, version.Minor, version.Build != -1 ? version.Build : 0);
+
+                var versionAttribute = MetadataHelper.GetAttributes<AssemblyInformationalVersionAttribute>(assembly)
+                                                     .Single();
+                if (versionAttribute != null)
+                {
+                    if (Version.TryParse(versionAttribute.InformationalVersion, out var v))
+                    {
+                        Version = v;
+                    }
+                }
+            }
         }
     }
 
@@ -271,7 +330,10 @@ namespace BepInEx
             if (attributes.Length == 0)
                 return null;
 
-            return (BepInPlugin) attributes[0];
+            var attribute = (BepInPlugin) attributes[0];
+            attribute.Update(pluginType);
+
+            return attribute;
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
Simplifies plugin info by (optionally) taking it from assembly attributes.

Example

`TestPlugin.csproj`
```xml
<Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
        <Version>1.0.0</Version>
        <Title>Test plugin</Title> <!-- defaults to assembly name (TestPlugin) -->
    </PropertyGroup>
</Project>
```


`TestPlugin.cs`
```cs
[BepInPlugin("com.example.testplugin")]
public class ReactorPlugin : BasePlugin
{
}
```

instead of (but still possible to allow multiple plugins in one assembly)

```cs
[BepInPlugin("com.example.testplugin", "Test plugin", "0.1.0")]
public class ReactorPlugin : BasePlugin
{
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
