### PR TITLE
WIP: Port Il2Cpp builds to .NET Standard 2.1

### DIFF
--- a/BepInEx.Bootstrap/BepInEx.Bootstrap.csproj
+++ b/BepInEx.Bootstrap/BepInEx.Bootstrap.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>BepInEx.Bootstrap</AssemblyTitle>
     <Product>BepInEx.Bootstrap</Product>
     <DebugType>none</DebugType>
-    <OutputPath>..\bin\patcher\</OutputPath>
+    <OutputPath>..\bin\Patcher\</OutputPath>
     <LangVersion>8</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>

--- a/BepInEx.Core/BepInEx.Core.csproj
+++ b/BepInEx.Core/BepInEx.Core.csproj
@@ -1,31 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net35</TargetFramework>
+    <TargetFrameworks>net35;netstandard2.1</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyTitle>BepInEx</AssemblyTitle>
     <Product>BepInEx</Product>
     <LangVersion>8</LangVersion>
+    <OutputPath>..\bin\Core\$(TargetFramework)</OutputPath>
+    <DocumentationFile>$(OutputPath)\BepInEx.Core.xml</DocumentationFile>
     <Description>Unity plugin injection framework</Description>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
-    <OutputPath>..\bin\</OutputPath>
-    <DocumentationFile>..\bin\BepInEx.Core.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <OutputPath>bin\$(Configuration)\</OutputPath>
-    <DocumentationFile />
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="HarmonyX" Version="2.3.1" />
-    <PackageReference Include="Mono.Cecil" Version="0.10.4" />
     <PackageReference Include="MonoMod.Utils" Version="20.11.26.2" />
     <PackageReference Include="SemanticVersioning" Version="1.3.0" />
   </ItemGroup>

--- a/BepInEx.Core/Console/Windows/Kon.cs
+++ b/BepInEx.Core/Console/Windows/Kon.cs
@@ -86,7 +86,9 @@ namespace BepInEx.ConsoleUtil
 
 		private static void SetConsoleColor(bool isBackground, ConsoleColor c)
 		{
+			#if NET35
 			new UIPermission(UIPermissionWindow.SafeTopLevelWindows).Demand();
+			#endif
 			var color = ConsoleColorToColorAttribute((short)c, isBackground);
 			bool flag;
 			var bufferInfo = GetBufferInfo(false, out flag);

--- a/BepInEx.IL2CPP/BepInEx.IL2CPP.csproj
+++ b/BepInEx.IL2CPP/BepInEx.IL2CPP.csproj
@@ -1,11 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AssemblyTitle>BepInEx.IL2CPP</AssemblyTitle>
     <Product>BepInEx.IL2CPP</Product>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\IL2CPP\</OutputPath>
     <LangVersion>8</LangVersion>
+    <Configurations>Debug;Release</Configurations>
+    <Platforms>AnyCPU</Platforms>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -25,7 +28,6 @@
       <HintPath>..\lib\Il2Cppmscorlib.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="UnhollowerBaseLib">
       <HintPath>..\lib\UnhollowerBaseLib.dll</HintPath>
       <Private>True</Private>
@@ -51,4 +53,14 @@
     <PackageReference Include="MonoMod.RuntimeDetour" Version="20.11.26.2" />
   </ItemGroup>
   <Import Project="..\BepInEx.Shared\BepInEx.Shared.projitems" Label="Shared" />
+  
+  <!-- CopyLocalLockFileAssemblies causes to also output shared assemblies: https://github.com/NuGet/Home/issues/4837#issuecomment-354536302 -->
+  <!-- Since all core assemblies usually follow naming of System.*, we just delete them for now -->
+  <Target Name="DeleteSys" AfterTargets="Build">
+    <ItemGroup>
+      <FilesToDelete Include="$(OutputPath)System.*.dll"/>
+    </ItemGroup>
+    <Delete Files="@(FilesToDelete)" />
+  </Target>
+  
 </Project>

--- a/BepInEx.Patcher/BepInEx.Patcher.csproj
+++ b/BepInEx.Patcher/BepInEx.Patcher.csproj
@@ -7,7 +7,7 @@
     <Product>BepInEx.Patcher</Product>
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>..\bin\patcher\</OutputPath>
+    <OutputPath>..\bin\Patcher\</OutputPath>
     <LangVersion>8</LangVersion>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/BepInEx.Preloader.Core/BepInEx.Preloader.Core.csproj
+++ b/BepInEx.Preloader.Core/BepInEx.Preloader.Core.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net35</TargetFramework>
+    <TargetFrameworks>net35;netstandard2.1</TargetFrameworks>
     <AssemblyTitle>BepInEx.Preloader.Core</AssemblyTitle>
     <Product>BepInEx.Preloader.Core</Product>
-    <OutputPath>..\bin\</OutputPath>
+    <OutputPath>..\bin\Core\$(TargetFramework)</OutputPath>
+    <DocumentationFile>$(OutputPath)\BepInEx.Preloader.Core.xml</DocumentationFile>
     <LangVersion>8</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
@@ -12,14 +13,12 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
-    <DocumentationFile>..\bin\BepInEx.Preloader.Core.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\BepInEx.Core\BepInEx.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="HarmonyX" Version="2.3.1" />
-    <PackageReference Include="Mono.Cecil" Version="0.10.4" />
     <PackageReference Include="MonoMod.RuntimeDetour" Version="20.11.26.2" />
     <PackageReference Include="MonoMod.Utils" Version="20.11.26.2" />
   </ItemGroup>

--- a/BepInEx.Preloader.Unity/BepInEx.Preloader.Unity.csproj
+++ b/BepInEx.Preloader.Unity/BepInEx.Preloader.Unity.csproj
@@ -3,7 +3,8 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyTitle>BepInEx.Preloader.Unity</AssemblyTitle>
     <Product>BepInEx.Preloader.Unity</Product>
-    <OutputPath>..\bin\</OutputPath>
+    <OutputPath>..\bin\Unity\</OutputPath>
+    <DocumentationFile>$(OutputPath)\BepInEx.Preloader.Unity.xml</DocumentationFile>
     <LangVersion>8</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
@@ -12,7 +13,6 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
-    <DocumentationFile>..\bin\BepInEx.Preloader.Unity.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\BepInEx.Core\BepInEx.Core.csproj" />

--- a/BepInEx.Unity/BepInEx.Unity.csproj
+++ b/BepInEx.Unity/BepInEx.Unity.csproj
@@ -4,6 +4,7 @@
     <AssemblyTitle>BepInEx.Unity</AssemblyTitle>
     <Product>BepInEx.Unity</Product>
     <OutputPath>..\bin\Unity\</OutputPath>
+    <DocumentationFile>$(OutputPath)\BepInEx.Unity.xml</DocumentationFile>
     <LangVersion>8</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
@@ -12,7 +13,6 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
-    <DocumentationFile>..\bin\BepInEx.Unity.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="UnityEngine">

--- a/BepInExTests/BepInExTests.csproj
+++ b/BepInExTests/BepInExTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
@@ -25,7 +25,7 @@
     <PackageReference Include="Iced" Version="1.6.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>

--- a/BepInExTests/TrampolineTests.cs
+++ b/BepInExTests/TrampolineTests.cs
@@ -49,10 +49,7 @@ namespace BepInEx.Tests
 
 			Disassemble(exampleCode, (ulong)exampleCodePointer.ToInt64());
 
-
-			int trampolineLength = TrampolineGenerator.Generate(exampleCodePointer, new IntPtr(0xBEEF), trampolineCodePointer, bitness);
-
-
+			DetourGenerator.CreateTrampolineFromFunction(exampleCodePointer, out var trampolineLength, out _);
 
 			Console.WriteLine("Modified:");
 			Console.WriteLine();

--- a/build.cake
+++ b/build.cake
@@ -89,7 +89,7 @@ Task("Build")
 
 const string DOORSTOP_VER_WIN = "3.1.0.0";
 const string DOORSTOP_VER_UNIX = "1.3.0.0";
-const string MONO_VER = "2020.12.23";
+const string MONO_VER = "2020.12.31";
 const string DOORSTOP_DLL = "winhttp.dll";
 Task("DownloadDependencies")
     .Does(() =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes Il2Cpp builds to now target .NET Standard 2.1.

## Description
<!--- Describe your changes in detail -->
This change migrates `BepInEx.IL2CPP` core to .NET Standard 2.1. To support this, `BepInEx.Core` and `BepInEx.Preloader.Core` were updated to build both net35 and netstandard2.1 targets. In addition, `BepInExTests` was updated to target netcoreapp3.1 to facilitate the change.

The code in `BepInEx.IL2CPP` was updated to not rely on `AppDomain` API directly as it is missing from .NET Standard 2.1 (but is present in mono). This was deemed fine as it was the only necessary change.

Finally, the build output was restructured: because core libraries now have multiple TFMs, they are now output into `bin/Core/<TFM>` folder. This change does not affect `IL2CPP` and `Unity` folders which are the actual build output (and which are used in CI).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since we use mono 6.12 on Il2Cpp builds, it is possible to build libraries against .NET Standard 2.1 which enables support for more API (e.g. C# 8 ranges and nullables). Given that especially even .NET Framework 4.8 does supports only .NET Standard 2.0, it makes more sense to take advantage of all available mono API.

In additon we already ship `netstandard.dll` as part of our mono to allow running .NET Standard plugins. As such, it makes sense to utilise the possibility in core library as well.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
CI script was tested and assured to still work.

Tested on a few games, game boots and existing plugins are loaded fine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
