### PR TITLE
Avoid LINQ call by using the expected type in the foreach loop

### DIFF
--- a/BepInEx.Core/Configuration/ConfigFile.cs
+++ b/BepInEx.Core/Configuration/ConfigFile.cs
@@ -549,7 +549,7 @@ namespace BepInEx.Configuration
             if (settingChanged == null) return;
 
             var args = new SettingChangedEventArgs(changedEntryBase);
-            foreach (var callback in settingChanged.GetInvocationList().Cast<EventHandler<SettingChangedEventArgs>>())
+            foreach (EventHandler<SettingChangedEventArgs> callback in settingChanged.GetInvocationList())
                 try
                 {
                     callback(sender, args);
@@ -565,7 +565,7 @@ namespace BepInEx.Configuration
             var configReloaded = ConfigReloaded;
             if (configReloaded == null) return;
 
-            foreach (var callback in configReloaded.GetInvocationList().Cast<EventHandler>())
+            foreach (EventHandler callback in configReloaded.GetInvocationList())
                 try
                 {
                     callback(this, EventArgs.Empty);


### PR DESCRIPTION
Preserves exception compatibility and behaves better, including
having improved codegen as a result.

See https://sharplab.io/#v2:CYLg1APgAgTAjAWAFBQMwAJboMLoN7LpGYYCmAbqQHYAu6AopbQBICGVwANqQE6ZQUA3IWIiiaTABZ0AOQD2NAJYAzAJ4AKAJRj8O4umVyepVgGMAFunWNqNNh248APNgB86CukVV+FAHQA4qQ0AJJU5HKmrEpyVAAyigDONFqaukj6mcT+YREA1qTqNOZJADToVACunJyawhlZ6AC+Oi1ITUA==

<!--- Provide a general summary of your changes in the Title above -->

## Description

Switched LINQ Cast call into a compiler introduced cast. It's faster and behaves identically.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [*] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
