### PR TITLE
API for accessing orphaned config entries

### DIFF
--- a/BepInEx.Core/Configuration/ConfigFile.cs
+++ b/BepInEx.Core/Configuration/ConfigFile.cs
@@ -297,6 +297,37 @@ namespace BepInEx.Configuration
         }
 
         /// <summary>
+        /// Pops an orphaned config entry from the file.
+        /// </summary>
+        /// <typeparam name="T">Expected type of the orphaned entry.</typeparam>
+        /// <param name="entry">Orphaned entry to pop.</param>
+        /// <param name="val">Out value of this entry (if it exists).</param>
+        /// <returns>True on successful get and remove.</returns>
+        public bool TryPopOrphanedEntry<T>(ConfigDefinition entry, out T val)
+        {
+            // Locking here does not deadlock, locks in .NET are reentrant https://stackoverflow.com/questions/391913/re-entrant-locks-in-c-sharp
+            lock (_ioLock)
+            {
+                if (!TryGetOrphanedEntry<T>(entry, out val))
+                    return false;
+                return _orphanedEntries.Remove(entry);
+            }
+        }
+
+        /// <summary>
+        /// Pops an orphaned config entry from the file.
+        /// </summary>
+        /// <typeparam name="T">Expected type of the orphaned entry.</typeparam>
+        /// <param name="section">Section of the orphaned entry to remove.</param>
+        /// <param name="key">Key of the orphaned entry to remove.</param>
+        /// <param name="val">Out value of this entry (if it exists).</param>
+        /// <returns>True on successful get and remove.</returns>
+        public bool TryPopOrphanedEntry<T>(string section, string key, out T val)
+        {
+            return TryPopOrphanedEntry<T>(new ConfigDefinition(section, key), out val);
+        }
+
+        /// <summary>
         /// Removes all orphaned config entries from this file.
         /// </summary>
         public void RemoveAllOrphanedEntries()

--- a/BepInEx.Core/Configuration/ConfigFile.cs
+++ b/BepInEx.Core/Configuration/ConfigFile.cs
@@ -287,8 +287,8 @@ namespace BepInEx.Configuration
         /// <summary>
         /// Removes an orphaned config entry from the file.
         /// </summary>
-        /// <param name="section">Section of orphaned entry to remove.</param>
-        /// <param name="key">Key of orphaned entry to remove.</param>
+        /// <param name="section">Section of the orphaned entry to remove.</param>
+        /// <param name="key">Key of the orphaned entry to remove.</param>
         /// <returns>True on success.</returns>
         public bool TryRemoveOrphanedEntry(string section, string key)
         {


### PR DESCRIPTION
## Description
Adds an API to ConfigFile that allows for the access of and removal of orphaned config entries.

## Motivation and Context
#208 

## How Has This Been Tested?
Waiting on additional input from discussion post above

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
