### PR TITLE
Update Bepin GOs to use HideAndDontSave flags

### DIFF
--- a/BepInEx/Bootstrap/Chainloader.cs
+++ b/BepInEx/Bootstrap/Chainloader.cs
@@ -288,6 +288,7 @@ namespace BepInEx.Bootstrap
 				Logger.LogMessage("Chainloader started");
 
 				ManagerObject = new GameObject("BepInEx_Manager");
+				ManagerObject.hideFlags = HideFlags.HideAndDontSave;
 
 				UnityEngine.Object.DontDestroyOnLoad(ManagerObject);
 

--- a/BepInEx/ThreadingHelper.cs
+++ b/BepInEx/ThreadingHelper.cs
@@ -33,6 +33,7 @@ namespace BepInEx
 		internal static void Initialize()
 		{
 			var go = new GameObject("BepInEx_ThreadingHelper");
+			go.hideFlags = HideFlags.HideAndDontSave;
 			DontDestroyOnLoad(go);
 			Instance = go.AddComponent<ThreadingHelper>();
 		}


### PR DESCRIPTION
## Description
To prevent forceful destruction of the manager GOs by the game (see Oddworld: Soulstorm) via
`Resources.UnloadUnusedAssets` we can use https://docs.unity3d.com/ScriptReference/HideFlags.HideAndDontSave.html

## Motivation and Context
 Oddworld: Soulstorm (for example) uses aggressive resource management approach that forcefully unloads any objects, including those that were set to DontDestroyOnLoad(). There are 3 possible workarounds:
1. Move away from GameObjects (unlikely, breaking)
2. Use custom loaders for specific game that will patch game's code (unlikely, not relevant to Bepin itself)
3. Resort to easier solution via custom object flags that will prevent it from being unloaded.

## How Has This Been Tested?
Preliminary testing on ` Oddworld: Soulstorm` (custom build of Unity 2019.4.12) for about an hour. Plugins used to be destroyed and unloaded after first scene change, now they persist.

## Screenshots (if appropriate):

## Checklist:
- [x] My code follows the code style of this project.