### PR TITLE
Remove BOM from UTF-8 File Encodings

### DIFF
--- a/BepInEx.Core/Configuration/ConfigFile.cs
+++ b/BepInEx.Core/Configuration/ConfigFile.cs
@@ -281,7 +281,7 @@ namespace BepInEx.Configuration
                 var directoryName = Path.GetDirectoryName(ConfigFilePath);
                 if (directoryName != null) Directory.CreateDirectory(directoryName);
 
-                using (var writer = new StreamWriter(ConfigFilePath, false, Encoding.UTF8))
+                using (var writer = new StreamWriter(ConfigFilePath, false, Utility.UTF8NoBom))
                 {
                     if (_ownerMetadata != null)
                     {

--- a/BepInEx.Core/Console/Windows/WindowsConsoleDriver.cs
+++ b/BepInEx.Core/Console/Windows/WindowsConsoleDriver.cs
@@ -55,7 +55,7 @@ namespace BepInEx
             }
 
             var originalOutStream = OpenFileStream(stdout);
-            StandardOut = new StreamWriter(originalOutStream, new UTF8Encoding(false))
+            StandardOut = new StreamWriter(originalOutStream, Utility.UTF8NoBom)
             {
                 AutoFlush = true
             };

--- a/BepInEx.Core/Logging/DiskLogListener.cs
+++ b/BepInEx.Core/Logging/DiskLogListener.cs
@@ -53,7 +53,7 @@ namespace BepInEx.Logging
                 localPath = $"LogOutput.{counter++}.log";
             }
 
-            LogWriter = TextWriter.Synchronized(new StreamWriter(fileStream, Encoding.UTF8));
+            LogWriter = TextWriter.Synchronized(new StreamWriter(fileStream, Utility.UTF8NoBom));
 
             if (delayedFlushing) FlushTimer = new Timer(o => { LogWriter?.Flush(); }, null, 2000, 2000);
 

--- a/BepInEx.Core/Utility.cs
+++ b/BepInEx.Core/Utility.cs
@@ -22,6 +22,11 @@ namespace BepInEx
         ///     <see cref="System.Reflection.Emit" /> namespace.
         /// </summary>
         public static bool CLRSupportsDynamicAssemblies => CheckSRE();
+        
+        /// <summary>
+        ///	An encoding for UTF-8 which does not emit a byte order mark (BOM). 
+        /// </summary>
+        public static Encoding UTF8NoBom { get; } = new UTF8Encoding(false);
 
         private static bool CheckSRE()
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Disables the byte order mark (BOM) from the UTF-8 encoding instances used to write to config files and log files. `WindowsConsoleDriver` uses pure UTF-8 as well, so I also adjusted it to reuse the same encoding instance as the others.

I also have another branch on my fork called `v5/remove-utf8-bom` in case this one is merged and you want to backport it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Discord recently introduced a feature that allowed for previewing text files without downloading them, but this never seems to work on log files. Upon further examination, it was because the files were equipped with a BOM.

I did further research and found that nobody argued in favor of UTF-8 BOM. The technical reason for this is that the BOM provides endianness information. However, UTF-8 uses singular bytes (instead of 4 or 2 bytes, like UTF-32 or UTF-16) and so endianness is of no concern (see: *[The Unicode Standard](http://www.unicode.org/versions/Unicode13.0.0/UnicodeStandard-13.0.pdf)*, section 2.6). Anecdotal reasons also included simple software not expecting the BOM, and the BOM being legitimate text in other encodings.

While this is arguably Discord's issue, I could not find any downsides and I'd rather fix this than open a Discord support ticket.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tests were performed using *Hot Dogs, Horse Shoes & Hand Grenades* (Unity Mono 5.6.3), in this order:
1. Without any prior config or log, it properly created the files without a BOM.
2. With the just-generated config and log, it produced no errors (such as ones that could have come from reading the config file).
3. With the console config entry set to true, launched H3VR and the console successfully appeared (to ensure the config was being read and a default was not being used).
4. With the config and log as UTF-8 BOM, I launched H3VR and both were successfully changed to pure UTF-8.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

I did not consider the encoding of config files to be part of the public API, but it might be of concern to software that handles configs or log files. I have already tested r2modman 3.1.9 on a Valheim config I saved as UTF-8.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
