### PR TITLE
Issue #229 fix

### DIFF
--- a/BepInEx.IL2CPP/IL2CPPChainloader.cs
+++ b/BepInEx.IL2CPP/IL2CPPChainloader.cs
@@ -51,10 +51,6 @@ namespace BepInEx.IL2CPP
             base.Initialize(gameExePath);
             Instance = this;
 
-            var version = //Version.Parse(Application.unityVersion);
-                Version.Parse(Process.GetCurrentProcess().MainModule.FileVersionInfo.FileVersion);
-
-            UnityVersionHandler.Initialize(version.Major, version.Minor, version.Build);
             ClassInjector.Detour = new UnhollowerDetourHandler();
 
             var gameAssemblyModule = Process.GetCurrentProcess().Modules.Cast<ProcessModule>()

--- a/BepInEx.IL2CPP/Preloader.cs
+++ b/BepInEx.IL2CPP/Preloader.cs
@@ -91,11 +91,11 @@ namespace BepInEx.IL2CPP
         private static void InitializeUnityVersion()
         {
             if (TryInitializeUnityVersion(ConfigUnityVersion.Value))
-                Log.LogDebug($"Unity version obtained from the config.");
+                Log.LogWarning($"Unity version obtained from the config.");
             else if (TryInitializeUnityVersion(Process.GetCurrentProcess().MainModule.FileVersionInfo.FileVersion))
                 Log.LogDebug($"Unity version obtained from main application module.");
             else
-                Log.LogWarning($"Running under default Unity version. UnityVersionHandler is not initialized.");
+                Log.LogError($"Running under default Unity version. UnityVersionHandler is not initialized.");
         }
 
         private static bool TryInitializeUnityVersion(string version)
@@ -117,21 +117,19 @@ namespace BepInEx.IL2CPP
                 if (success && parts.Length > 2)
                     success = int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out build);
 
-                if (success)
+                if (!success)
                 {
-                    UnityVersionHandler.Initialize(major, minor, build);
-                    Log.LogInfo($"Running under Unity v{major}.{minor}.{build}");
-                    return true;
-                }
-                else
-                {
-                    Log.LogWarning($"Failed to parse Unity version: {version}");
+                    Log.LogError($"Failed to parse Unity version: {version}");
                     return false;
                 }
+
+                UnityVersionHandler.Initialize(major, minor, build);
+                Log.LogInfo($"Running under Unity v{major}.{minor}.{build}");
+                return true;
             }
             catch (Exception ex)
             {
-                Log.LogWarning($"Failed to parse Unity version: {ex}");
+                Log.LogError($"Failed to parse Unity version: {ex}");
                 return false;
             }
         }


### PR DESCRIPTION
## Description
Fixed issue #229.
* Now we manually parse the first three components of the version.
* Now we can override the version in the config file: `[Unity] Version = 2019.4.16`
* Moved version initialization to Preloader to avoid confusion in the logs. 