### PR TITLE
Custom Save and Reload implementations for ConfigFile

### DIFF
--- a/BepInEx.Core/Configuration/ConfigFile.cs
+++ b/BepInEx.Core/Configuration/ConfigFile.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -273,7 +273,7 @@ namespace BepInEx.Configuration
         /// <summary>
         /// Overridable reload implementation
         /// </summary>
-        public virtual void ReloadImplementation()
+        protected virtual void ReloadImplementation()
         {
             OrphanedEntries.Clear();
 
@@ -324,7 +324,7 @@ namespace BepInEx.Configuration
         /// <summary>
         /// Overridable save implementation
         /// </summary>
-        public virtual void SaveImplementation()
+        protected virtual void SaveImplementation()
         {
             var directoryName = Path.GetDirectoryName(ConfigFilePath);
             if (directoryName != null) Directory.CreateDirectory(directoryName);

--- a/BepInEx.Unity/BaseUnityPlugin.cs
+++ b/BepInEx.Unity/BaseUnityPlugin.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using BepInEx.Configuration;
 using BepInEx.Logging;
 using UnityEngine;
@@ -32,7 +33,14 @@ namespace BepInEx
 
             Logger = Logging.Logger.CreateLogSource(metadata.Name);
 
-            Config = new ConfigFile(Utility.CombinePaths(Paths.ConfigPath, metadata.GUID + ".cfg"), false, metadata);
+            if (this.GetType().GetCustomAttributes(typeof(BepInConfigType), true).FirstOrDefault() is BepInConfigType configTypeAttribute)
+            {
+                Config = (ConfigFile)Activator.CreateInstance(configTypeAttribute.ConfigFileType, new object[] { Utility.CombinePaths(Paths.ConfigPath, metadata.GUID + ".cfg"), false, metadata });
+            }
+            else
+            {
+                Config = new ConfigFile(Utility.CombinePaths(Paths.ConfigPath, metadata.GUID + ".cfg"), false, metadata);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Made ConfigFile class more versatile with virtual Save and Reload methods.
The type to use for the ConfigFile implementation can be added as BepInConfigType attribute to the BaseUnityPlugin class.

## Motivation and Context
More and more games go online, so we had to work around issues involving server side only configuration values, but still keep them all inside one ConfigFile instance.
This not also addresses this, it also addresses others who might want to use their own file format.
The custom implementation can be done overriding SaveImplementation() and ReloadImplementation() methods.

## How Has This Been Tested?
Checked it inside our Valheim plugin, our ConfigFile implementation is instanced correctly and loaded/saved also correctly.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
