### PR TITLE
Custom ConfigFile classes for v5lts

### DIFF
--- a/BepInEx/Configuration/ConfigFile.cs
+++ b/BepInEx/Configuration/ConfigFile.cs
@@ -110,7 +110,7 @@ namespace BepInEx.Configuration
 		/// <summary>
 		/// Overridable reload implementation
 		/// </summary>
-		public virtual void ReloadImplementation()
+		protected virtual void ReloadImplementation()
 		{
 			OrphanedEntries.Clear();
 
@@ -161,7 +161,7 @@ namespace BepInEx.Configuration
 		/// <summary>
 		/// Overridable Save implementation
 		/// </summary>
-		public virtual void SaveImplementation()
+		protected virtual void SaveImplementation()
 		{
 			string directoryName = Path.GetDirectoryName(ConfigFilePath);
 			if (directoryName != null) Directory.CreateDirectory(directoryName);

--- a/BepInEx/Configuration/ConfigFile.cs
+++ b/BepInEx/Configuration/ConfigFile.cs
@@ -97,7 +97,7 @@ namespace BepInEx.Configuration
 		/// <summary>
 		/// Reloads the config from disk. Unsaved changes are lost.
 		/// </summary>
-		public void Reload()
+		public virtual void Reload()
 		{
 			lock (_ioLock)
 			{
@@ -142,7 +142,7 @@ namespace BepInEx.Configuration
 		/// <summary>
 		/// Writes the config to disk.
 		/// </summary>
-		public void Save()
+		public virtual void Save()
 		{
 			lock (_ioLock)
 			{

--- a/BepInEx/Contract/Attributes.cs
+++ b/BepInEx/Contract/Attributes.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using BepInEx.Bootstrap;
+using BepInEx.Configuration;
 using Mono.Cecil;
 
 namespace BepInEx
@@ -217,6 +218,41 @@ namespace BepInEx
 		}
 	}
 
+	/// <summary>
+	/// This attribute specifies which <see cref="ConfigFile">ConfigFile</see> implementation to use for the plugin's configuration.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+	public class BepInConfigType : Attribute
+	{
+		/// <summary>
+		/// Type of the ConfigFile implementation
+		/// </summary>
+		public Type ConfigFileType { get; set; }
+
+		/// <param name="configFileType">Type of the <see cref="ConfigFile">ConfigFile</see> child class to use</param>
+		public BepInConfigType(Type configFileType)
+		{
+			Type temp = configFileType;
+			bool isDescendant = false;
+
+			// Walk the base types to check if it is a child class of ConfigFile
+			while (temp != null && !isDescendant)
+			{
+				isDescendant |= temp.BaseType == typeof(ConfigFile);
+				if (!isDescendant)
+				{
+					temp = temp.BaseType;
+				}
+			}
+
+			if (!isDescendant)
+			{
+				throw new Exception($"Type {configFileType.Name} is not a child class of ConfigFile.");
+			}
+
+			ConfigFileType = configFileType;
+		}
+	}
 	#endregion
 
 	#region MetadataHelper

--- a/BepInEx/Contract/BaseUnityPlugin.cs
+++ b/BepInEx/Contract/BaseUnityPlugin.cs
@@ -55,11 +55,26 @@ namespace BepInEx
 
 			string configRoot = Chainloader.IsEditor ? "." : Paths.ConfigPath;
 
-			if (this.GetType().GetCustomAttributes(typeof(BepInConfigType), true).FirstOrDefault() is BepInConfigType configTypeAttribute)
+			bool configCreated = false;
+			if (this.GetType() != typeof(BaseUnityPlugin))
 			{
-				Config = (ConfigFile)Activator.CreateInstance(configTypeAttribute.ConfigFileType, new object[] { Utility.CombinePaths(configRoot, metadata.GUID + ".cfg"), false, metadata });
+				Type temp = this.GetType();
+				while (temp != null && temp != typeof(BaseUnityPlugin))
+				{
+					if (temp.GetCustomAttributes(typeof(BepInConfigType), false).Any())
+					{
+						BepInConfigType configTypeAttribute =
+							temp.GetCustomAttributes(typeof(BepInConfigType), false).First() as BepInConfigType;
+						Config = (ConfigFile)Activator.CreateInstance(configTypeAttribute.ConfigFileType, new object[] { Utility.CombinePaths(configRoot, metadata.GUID + ".cfg"), false, metadata });
+						configCreated = true;
+						break;
+					}
+
+					temp = temp.BaseType;
+				}
 			}
-			else
+
+			if (!configCreated)
 			{
 				Config = new ConfigFile(Utility.CombinePaths(configRoot, metadata.GUID + ".cfg"), false, metadata);
 			}

--- a/BepInEx/Contract/BaseUnityPlugin.cs
+++ b/BepInEx/Contract/BaseUnityPlugin.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using BepInEx.Bootstrap;
 using BepInEx.Configuration;
 using BepInEx.Logging;
@@ -53,7 +54,15 @@ namespace BepInEx
 			Logger = Logging.Logger.CreateLogSource(metadata.Name);
 
 			string configRoot = Chainloader.IsEditor ? "." : Paths.ConfigPath;
-			Config = new ConfigFile(Utility.CombinePaths(configRoot, metadata.GUID + ".cfg"), false, metadata);
+
+			if (this.GetType().GetCustomAttributes(typeof(BepInConfigType), true).FirstOrDefault() is BepInConfigType configTypeAttribute)
+			{
+				Config = (ConfigFile)Activator.CreateInstance(configTypeAttribute.ConfigFileType, new object[] { Utility.CombinePaths(configRoot, metadata.GUID + ".cfg"), false, metadata });
+			}
+			else
+			{
+				Config = new ConfigFile(Utility.CombinePaths(configRoot, metadata.GUID + ".cfg"), false, metadata);
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Made ConfigFile class more versatile with virtual Save and Reload methods.
The type to use for the ConfigFile implementation can be added as BepInConfigType attribute to the BaseUnityPlugin class.

## Motivation and Context
More and more games go online, so we had to work around issues involving server side only configuration values, but still keep them all inside one ConfigFile instance.
This not also addresses this, it also addresses others who might want to use their own file format.
The custom implementation can be done overriding SaveImplementation() and ReloadImplementation() methods.

## How Has This Been Tested?
Checked it inside our Valheim plugin, our ConfigFile implementation is instanced correctly and loaded/saved also correctly.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
