### PR TITLE
Use Il2CppDumper dummy assemblies directly

### DIFF
--- a/BepInEx.IL2CPP/BepInEx.IL2CPP.csproj
+++ b/BepInEx.IL2CPP/BepInEx.IL2CPP.csproj
@@ -27,8 +27,8 @@
     <PackageReference Include="Iced" Version="1.11.0" />
       <PackageReference Include="Il2CppAssemblyUnhollower.BaseLib" Version="0.4.15.3" />
     <PackageReference Include="Il2CppAssemblyUnhollower.BaseLib.Legacy" Version="0.4.15.2" />
-    <PackageReference Include="Il2CppAssemblyUnhollower.Tool" Version="0.4.15.2" />
-    <PackageReference Include="Il2CppDumper" Version="6.6.3" />
+    <PackageReference Include="Il2CppAssemblyUnhollower.Tool" Version="0.4.15.3" />
+    <PackageReference Include="Il2CppDumper" Version="6.6.4" />
     <PackageReference Include="Il2CppReferenceLibs.Core" Version="1.0.0" IncludeAssets="compile" />
       <PackageReference Include="MonoMod.RuntimeDetour" Version="21.4.21.3" />
   </ItemGroup>


### PR DESCRIPTION
## Description
Makes Il2CppAssemblyUnhollower (https://github.com/BepInEx/Il2CppAssemblyUnhollower/pull/3) use Il2cppDumper's (https://github.com/BepInEx/Il2CppDumper/pull/2) dummy dlls directly instead of relying on file system (which is slower, prone to file locks and redundant)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
