### PR TITLE
Add automatic downloading of unity base libraries

### DIFF
--- a/BepInEx.IL2CPP/Preloader.cs
+++ b/BepInEx.IL2CPP/Preloader.cs
@@ -23,6 +23,8 @@ namespace BepInEx.IL2CPP
         // TODO: This is not needed, maybe remove? (Instance is saved in IL2CPPChainloader itself)
         private static IL2CPPChainloader Chainloader { get; set; }
 
+        public static Version UnityVersion { get; private set; }
+
         public static void Run()
         {
             try
@@ -51,13 +53,12 @@ namespace BepInEx.IL2CPP
                 LogSupport.TraceHandler += UnhollowerLog.LogDebug;
                 LogSupport.ErrorHandler += UnhollowerLog.LogError;
 
+                InitializeUnityVersion();
 
                 if (ProxyAssemblyGenerator.CheckIfGenerationRequired())
                     ProxyAssemblyGenerator.GenerateAssemblies();
-                
-                
-                InitializeUnityVersion();
 
+                UnityVersionHandler.Initialize(UnityVersion.Major, UnityVersion.Minor, UnityVersion.Build);
 
                 using (var assemblyPatcher = new AssemblyPatcher())
                 {
@@ -123,8 +124,8 @@ namespace BepInEx.IL2CPP
                     return false;
                 }
 
-                UnityVersionHandler.Initialize(major, minor, build);
-                Log.LogInfo($"Running under Unity v{major}.{minor}.{build}");
+                UnityVersion = new Version(major, minor, build);
+                Log.LogInfo($"Running under Unity v{UnityVersion}");
                 return true;
             }
             catch (Exception ex)

--- a/BepInEx.IL2CPP/ProxyAssemblyGenerator.cs
+++ b/BepInEx.IL2CPP/ProxyAssemblyGenerator.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
 using AssemblyUnhollower;
+using BepInEx.Configuration;
 using BepInEx.Logging;
 using HarmonyLib;
 using Il2CppDumper;
@@ -12,6 +15,11 @@ namespace BepInEx.IL2CPP
 {
     internal static class ProxyAssemblyGenerator
     {
+        private static readonly ConfigEntry<string> ConfigUnityBaseLibrariesSource = ConfigFile.CoreConfig.Bind(
+         "IL2CPP", "UnityBaseLibrariesSource",
+         "http://unitylibs.bepinex.dev/{VERSION}.zip",
+         "Source of the unity base libraries downloaded at runtime. If empty, nothing will be downloaded.");
+
         private static readonly ManualLogSource Il2cppDumperLogger = Logger.CreateLogSource("Il2CppDumper");
 
         public static string GameAssemblyPath => Path.Combine(Paths.GameRootPath, "GameAssembly.dll");
@@ -74,7 +82,7 @@ namespace BepInEx.IL2CPP
 
             runner.Setup(Paths.ExecutablePath, Preloader.IL2CPPUnhollowedPath, Paths.BepInExRootPath,
                          Paths.ManagedPath);
-            runner.GenerateAssembliesInternal(new AppDomainListener());
+            runner.GenerateAssembliesInternal(new AppDomainListener(), Preloader.UnityVersion.ToString(3));
 
             AppDomain.Unload(domain);
 
@@ -137,8 +145,29 @@ namespace BepInEx.IL2CPP
                 AppDomain.CurrentDomain.AddCecilPlatformAssemblies(UnityBaseLibsDirectory);
             }
 
-            public void GenerateAssembliesInternal(AppDomainListener listener)
+            public void GenerateAssembliesInternal(AppDomainListener listener, string unityVersion)
             {
+                var source =
+                    ConfigUnityBaseLibrariesSource.Value.Replace("{VERSION}", unityVersion);
+
+                if (!string.IsNullOrEmpty(source))
+                {
+                    listener.DoPreloaderLog("Downloading unity base libraries", LogLevel.Message);
+
+                    Directory.CreateDirectory(UnityBaseLibsDirectory);
+
+                    foreach (var dllFile in Directory.EnumerateFiles(UnityBaseLibsDirectory, "*.dll"))
+                    {
+                        File.Delete(dllFile);
+                    }
+
+                    using var httpClient = new HttpClient();
+                    using var zipStream = httpClient.GetStreamAsync(source).GetAwaiter().GetResult();
+                    using var zipArchive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+
+                    zipArchive.ExtractToDirectory(UnityBaseLibsDirectory);
+                }
+
                 listener.DoPreloaderLog("Generating Il2CppUnhollower assemblies", LogLevel.Message);
 
                 Directory.CreateDirectory(Preloader.IL2CPPUnhollowedPath);

--- a/BepInEx.IL2CPP/ProxyAssemblyGenerator.cs
+++ b/BepInEx.IL2CPP/ProxyAssemblyGenerator.cs
@@ -17,7 +17,7 @@ namespace BepInEx.IL2CPP
     {
         private static readonly ConfigEntry<string> ConfigUnityBaseLibrariesSource = ConfigFile.CoreConfig.Bind(
          "IL2CPP", "UnityBaseLibrariesSource",
-         "http://unitylibs.bepinex.dev/{VERSION}.zip",
+         "http://unity.bepinex.dev/libraries/{VERSION}.zip",
          "Source of the unity base libraries downloaded at runtime. If empty, nothing will be downloaded.");
 
         private static readonly ManualLogSource Il2cppDumperLogger = Logger.CreateLogSource("Il2CppDumper");


### PR DESCRIPTION
- [x] Migrate default config to the new base libs location
- [x] Figure out why `MonoPosixHelper.dll` is in `MonoBleedingEdge/EmbedRuntime/` and why mono really wants it in the `Managed/`
- [x] Bundle `System.IO.Compression.dll` and `System.IO.Compression.FileSystem.dll` with BepInEx/mono