### PR TITLE
Extend bootup info logging

### DIFF
--- a/BepInEx.Preloader/Preloader.cs
+++ b/BepInEx.Preloader/Preloader.cs
@@ -50,7 +50,7 @@ namespace BepInEx.Preloader
 				PreloaderLog = new PreloaderConsoleListener();
 				Logger.Listeners.Add(PreloaderLog);
 
-				var version = typeof(Paths).Assembly.GetName().Version;
+				Version version = typeof(Paths).Assembly.GetName().Version;
 
 				string consoleTile = $"BepInEx {version} - {Paths.ProcessName} ({File.GetLastWriteTime(Paths.ExecutablePath)})";
 

--- a/BepInEx.Preloader/Preloader.cs
+++ b/BepInEx.Preloader/Preloader.cs
@@ -50,7 +50,9 @@ namespace BepInEx.Preloader
 				PreloaderLog = new PreloaderConsoleListener();
 				Logger.Listeners.Add(PreloaderLog);
 
-				string consoleTile = $"BepInEx {typeof(Paths).Assembly.GetName().Version} - {Paths.ProcessName}";
+				var version = typeof(Paths).Assembly.GetName().Version;
+
+				string consoleTile = $"BepInEx {version} - {Paths.ProcessName} ({File.GetLastWriteTime(Paths.ExecutablePath)})";
 
 				if (ConsoleManager.ConsoleActive)
 					ConsoleManager.SetConsoleTitle(consoleTile);
@@ -82,6 +84,9 @@ namespace BepInEx.Preloader
 					Patcher = PatchEntrypoint,
 					TypeName = "BepInEx.Chainloader"
 				});
+
+				Logger.Log(LogLevel.Info,
+					$"Loaded 1 patcher method from [BepInEx.Preloader {version}]");
 
 				AssemblyPatcher.AddPatchersFromDirectory(Paths.PatcherPluginPath);
 


### PR DESCRIPTION
Adds logging for game version (last modification time) and logs the preloader patcher being added.

## Description
Adds two extra tidbits of information for logging:
* The last time the executable was modified
* That the preloader patcher has been loaded.

## Motivation and Context
Detecting which version of a game is ran helps people running technical support for BepInEx distributions to identify what support needs to be provided.
The default logging does not state it adds the preloader patcher, but then does count it in the total patchers loaded, confusing end users.

## How Has This Been Tested?
```
[Message:   BepInEx] BepInEx 5.4.9.0 - Risk of Rain 2 (02/05/2020 13:50:22)
[Info   :   BepInEx] Running under Unity v2018.4.16.15133130
[Info   :   BepInEx] CLR runtime version: 4.0.30319.17020
[Info   :   BepInEx] Supports SRE: False
[Info   :   BepInEx] System platform: Bits64, Windows
[Message:   BepInEx] Preloader started
[Info   :   BepInEx] Loaded 1 patcher method from [BepInEx.Preloader 5.4.9.0]
[Info   :   BepInEx] 1 patcher plugin loaded
[Info   :   BepInEx] Patching [UnityEngine.CoreModule] with [BepInEx.Chainloader]
...
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
