### PR TITLE
Make stacktraces Error instead of Debug

### DIFF
--- a/BepInEx.Core/Bootstrap/BaseChainloader.cs
+++ b/BepInEx.Core/Bootstrap/BaseChainloader.cs
@@ -340,11 +340,7 @@ namespace BepInEx.Bootstrap
                         invalidPlugins.Add(plugin.Metadata.GUID);
                         Plugins.Remove(plugin.Metadata.GUID);
 
-                        Logger.LogError($"Error loading [{plugin}] : {ex.Message}");
-                        if (ex is ReflectionTypeLoadException re)
-                            Logger.LogDebug(TypeLoader.TypeLoadExceptionToString(re));
-                        else
-                            Logger.LogDebug(ex);
+                        Logger.LogError($"Error loading [{plugin}]: {(ex is ReflectionTypeLoadException re ? TypeLoader.TypeLoadExceptionToString(re) : ex)}");
                     }
                 }
             }
@@ -356,8 +352,7 @@ namespace BepInEx.Bootstrap
                 }
                 catch { }
 
-                Logger.LogError("Error occurred starting the game");
-                Logger.LogDebug(ex);
+                Logger.LogError("Error occurred starting the game: " + ex);
             }
 
             Logger.LogMessage("Chainloader startup complete");
@@ -371,8 +366,7 @@ namespace BepInEx.Bootstrap
             }
             catch (Exception e)
             {
-                Logger.LogWarning($"Couldn't run Module constructor for {assembly.FullName}::{plugin.TypeName}: {e.Message}");
-                Logger.LogDebug(e);
+                Logger.LogWarning($"Couldn't run Module constructor for {assembly.FullName}::{plugin.TypeName}: {e}");
             }
         }
 

--- a/BepInEx.Preloader.Core/Patching/AssemblyPatcher.cs
+++ b/BepInEx.Preloader.Core/Patching/AssemblyPatcher.cs
@@ -192,11 +192,7 @@ namespace BepInEx.Preloader.Core
                     }
                     catch (Exception e)
                     {
-                        Logger.LogError($"Failed to load patcher [{patcherPlugin.TypeName}]: {e.Message}");
-                        if (e is ReflectionTypeLoadException re)
-                            Logger.LogDebug(TypeLoader.TypeLoadExceptionToString(re));
-                        else
-                            Logger.LogDebug(e.ToString());
+                        Logger.LogError($"Failed to load patcher [{patcherPlugin.TypeName}]: {(e is ReflectionTypeLoadException re ? TypeLoader.TypeLoadExceptionToString(re) : e)}");
                     }
 
                 var assName = ass.GetName();


### PR DESCRIPTION
Currently stacktraces are logged with Debug log level which is not enabled by default making logs sent by users useless, this fixes it