### PR TITLE
Set ConsoleManager alreadyActive on wine

### DIFF
--- a/BepInEx.Core/Console/Windows/WindowsConsoleDriver.cs
+++ b/BepInEx.Core/Console/Windows/WindowsConsoleDriver.cs
@@ -30,7 +30,7 @@ namespace BepInEx
 
         public void Initialize(bool alreadyActive)
         {
-            ConsoleActive = alreadyActive;
+            ConsoleActive = alreadyActive || Console.WindowWidth != 0 && Console.WindowHeight != 0;
             
             if (alreadyActive)
             {

--- a/BepInEx.IL2CPP/Preloader.cs
+++ b/BepInEx.IL2CPP/Preloader.cs
@@ -30,7 +30,7 @@ namespace BepInEx.IL2CPP
         {
             try
             {
-                ConsoleManager.Initialize(Console.WindowWidth != 0 && Console.WindowHeight != 0);
+                ConsoleManager.Initialize(false);
 
                 PreloaderLog = new PreloaderConsoleListener();
                 Logger.Listeners.Add(PreloaderLog);


### PR DESCRIPTION
## Description
Set ConsoleManager's alreadyActive in IL2CPP and wine (as it doesn't affect windows) when the console is already present

## Motivation and Context
wineconsole is ugly and slow (and by slow I mean slow)
![image](https://user-images.githubusercontent.com/35262707/138566878-a4829b9e-20a8-4c2b-b373-4ab035ed8008.png)

## How Has This Been Tested?
- Windows: works as always
- Linux on KDE with Konsole

## Screenshots (if appropriate):
Launched from terminal (konsole)
![image](https://user-images.githubusercontent.com/35262707/138566753-0af83dc2-6ef7-4644-8a8f-05b7ff6e28b8.png)

Launched from file explorer (dolphin)
![image](https://user-images.githubusercontent.com/35262707/138566787-473e0cfe-7bd9-416a-a2b4-95493466dc01.png)

