### PR TITLE
Mutex

### DIFF
--- a/BepInEx.IL2CPP/DoorstopEntrypoint.cs
+++ b/BepInEx.IL2CPP/DoorstopEntrypoint.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using BepInEx.Preloader.Core;
 
 namespace BepInEx.IL2CPP
@@ -62,6 +63,9 @@ namespace BepInEx.IL2CPP
         /// </param>
         public static void Main(string[] args)
         {
+            var mutex = new Mutex(false, typeof(DoorstopEntrypoint).FullName);
+            mutex.WaitOne();
+            
             // We set it to the current directory first as a fallback, but try to use the same location as the .exe file.
             var silentExceptionLog = $"preloader_{DateTime.Now:yyyyMMdd_HHmmss_fff}.log";
 
@@ -83,6 +87,8 @@ namespace BepInEx.IL2CPP
             {
                 File.WriteAllText(silentExceptionLog, ex.ToString());
             }
+            
+            mutex.ReleaseMutex();
         }
 
         public static Assembly ResolveCurrentDirectory(object sender, ResolveEventArgs args)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a mutex which will prevent other instances of BepInEx from loading until the current instance has finished loading

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prevents access violations when multiple instances of the same game are opened too quickly

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested by launching four instances of Among Us using a script which functioned as expected given the changes made

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
