### PR TITLE
Auto inject Il2Cpp-Types

### DIFF
--- a/BepInEx.IL2CPP/IL2CPPChainloader.cs
+++ b/BepInEx.IL2CPP/IL2CPPChainloader.cs
@@ -156,9 +156,17 @@ namespace BepInEx.IL2CPP
 
         public override BasePlugin LoadPlugin(PluginInfo pluginInfo, Assembly pluginAssembly)
         {
-            var type = pluginAssembly.GetType(pluginInfo.TypeName);
+            foreach(var type in pluginAssembly.DefinedTypes)
+            {
+                if(typeof(Il2CppObjectBase).IsAssignableFrom(type) && !ClassInjector.IsTypeRegisteredInIl2Cpp(type))
+                {
+                    ClassInjector.RegisterTypeInIl2Cpp(type);
+                }
+            }
 
-            var pluginInstance = (BasePlugin)Activator.CreateInstance(type);
+            var pluginType = pluginAssembly.GetType(pluginInfo.TypeName);
+
+            var pluginInstance = (BasePlugin)Activator.CreateInstance(pluginType);
 
             pluginInstance.Load();
 

--- a/BepInEx.IL2CPP/IL2CPPChainloader.cs
+++ b/BepInEx.IL2CPP/IL2CPPChainloader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -156,13 +156,7 @@ namespace BepInEx.IL2CPP
 
         public override BasePlugin LoadPlugin(PluginInfo pluginInfo, Assembly pluginAssembly)
         {
-            foreach(var type in pluginAssembly.DefinedTypes)
-            {
-                if(typeof(Il2CppObjectBase).IsAssignableFrom(type) && !ClassInjector.IsTypeRegisteredInIl2Cpp(type))
-                {
-                    ClassInjector.RegisterTypeInIl2Cpp(type);
-                }
-            }
+            PluginClassInjector.RegisterAssemblyInIl2Cpp(pluginAssembly);
 
             var pluginType = pluginAssembly.GetType(pluginInfo.TypeName);
 

--- a/BepInEx.IL2CPP/PluginClassInjector.cs
+++ b/BepInEx.IL2CPP/PluginClassInjector.cs
@@ -6,6 +6,7 @@ using UnhollowerRuntimeLib;
 namespace BepInEx.IL2CPP
 {
 
+    [AttributeUsage(AttributeTargets.Class)]
     public class Il2CppInterfaces : Attribute
     {
 
@@ -18,20 +19,29 @@ namespace BepInEx.IL2CPP
 
     }
 
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class)]
+    public class DontAutoRegisterInIl2Cpp : Attribute { }
+
     internal class PluginClassInjector
     {
 
         public static void RegisterAssemblyInIl2Cpp(Assembly pluginAssembly)
         {
+            if (pluginAssembly.GetCustomAttribute<DontAutoRegisterInIl2Cpp>() != null) return;
+
             foreach (var type in pluginAssembly.DefinedTypes)
                 if (typeof(Il2CppObjectBase).IsAssignableFrom(type) && !ClassInjector.IsTypeRegisteredInIl2Cpp(type))
                     RegisterTypeInIl2Cpp(type);
         }
 
-        public static void RegisterTypeInIl2Cpp(Type type)
+        public static bool RegisterTypeInIl2Cpp(Type type)
         {
+            if(type.Assembly.GetCustomAttribute<DontAutoRegisterInIl2Cpp>() != null) return false;
+            if (type.GetCustomAttribute<DontAutoRegisterInIl2Cpp>() != null) return false;
+
             if (!ClassInjector.IsTypeRegisteredInIl2Cpp(type.BaseType))
-                RegisterTypeInIl2Cpp(type.BaseType);
+                if (!RegisterTypeInIl2Cpp(type.BaseType))
+                    return false;
 
             var interfaces = type.GetCustomAttribute<Il2CppInterfaces>();
 
@@ -39,6 +49,8 @@ namespace BepInEx.IL2CPP
                 ClassInjector.RegisterTypeInIl2CppWithInterfaces(type, true, interfaces.Interfaces);
             else
                 ClassInjector.RegisterTypeInIl2Cpp(type);
+
+            return true;
         }
 
     }

--- a/BepInEx.IL2CPP/PluginClassInjector.cs
+++ b/BepInEx.IL2CPP/PluginClassInjector.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Reflection;
+using UnhollowerBaseLib;
+using UnhollowerRuntimeLib;
+
+namespace BepInEx.IL2CPP
+{
+
+    public class Il2CppInterfaces : Attribute
+    {
+
+        public Type[] Interfaces { get; protected set; }
+
+        public Il2CppInterfaces(params Type[] interfaces)
+        {
+            Interfaces = interfaces;
+        }
+
+    }
+
+    internal class PluginClassInjector
+    {
+
+        public static void RegisterAssemblyInIl2Cpp(Assembly pluginAssembly)
+        {
+            foreach (var type in pluginAssembly.DefinedTypes)
+                if (typeof(Il2CppObjectBase).IsAssignableFrom(type) && !ClassInjector.IsTypeRegisteredInIl2Cpp(type))
+                    RegisterTypeInIl2Cpp(type);
+        }
+
+        public static void RegisterTypeInIl2Cpp(Type type)
+        {
+            if (!ClassInjector.IsTypeRegisteredInIl2Cpp(type.BaseType))
+                RegisterTypeInIl2Cpp(type.BaseType);
+
+            var interfaces = type.GetCustomAttribute<Il2CppInterfaces>();
+
+            if (interfaces != null)
+                ClassInjector.RegisterTypeInIl2CppWithInterfaces(type, true, interfaces.Interfaces);
+            else
+                ClassInjector.RegisterTypeInIl2Cpp(type);
+        }
+
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With this change the LoadPlugin method will automatically search every Type which inherits Il2CppObjectBase in the plugin assembly and registers it

## Motivation and Context
It makes creating new types easier, because you don't have to create a bunch of ClassInjector.RegisterTypeInIl2Cpp

## How Has This Been Tested?
I tested it be creating a plugin which has multiple MonoBehaviour without ClassInjector.RegisterTypeInIl2Cpp and then adding them to a GameObject

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
