### PR TITLE
Support returning Il2Cpp ienumerators which had been compiler generated

### DIFF
--- a/BepInEx.IL2CPP/Utils/Collections/Il2CppManagedEnumerator.cs
+++ b/BepInEx.IL2CPP/Utils/Collections/Il2CppManagedEnumerator.cs
@@ -35,7 +35,7 @@ namespace BepInEx.IL2CPP.Utils.Collections
 
         public Object Current => enumerator.Current switch
         {
-            Il2CppIEnumerator i => new Il2CppManagedEnumerator(new ManagedIl2CppEnumerator(i)),
+            Il2CppIEnumerator i => i.Cast<Object>(),
             IEnumerator e => new Il2CppManagedEnumerator(e),
             Object oo     => oo,
             { } obj       => ManagedToIl2CppObject(obj),

--- a/BepInEx.IL2CPP/Utils/Collections/Il2CppManagedEnumerator.cs
+++ b/BepInEx.IL2CPP/Utils/Collections/Il2CppManagedEnumerator.cs
@@ -35,6 +35,7 @@ namespace BepInEx.IL2CPP.Utils.Collections
 
         public Object Current => enumerator.Current switch
         {
+            Il2CppIEnumerator i => new Il2CppManagedEnumerator(new ManagedIl2CppEnumerator(i)),
             IEnumerator e => new Il2CppManagedEnumerator(e),
             Object oo     => oo,
             { } obj       => ManagedToIl2CppObject(obj),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Due to the nature of unhollower, ienumerators which were compiler generated and not explcitly defined inherit from il2cppobjectbase and thus are not handled by the current Il2CppManagedIEnumerator. This change adds support for this

## Description
<!--- Describe your changes in detail -->
Added an additional case to the current property in Il2CppManagedIEnumerator

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It allows for returning non explicitly defined IEnumertors which may be useful if the game implements a routine you would like to use
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested in Among Us (Unity v2020.3.7) and appears to function as expected
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
