### PR TITLE
Preloader.Unity: add troubleshooting hint for stripped assemblies

### DIFF
--- a/BepInEx.Preloader.Unity/DoorstopEntrypoint.cs
+++ b/BepInEx.Preloader.Unity/DoorstopEntrypoint.cs
@@ -56,13 +56,25 @@ namespace BepInEx.Preloader.Unity
 
         private static void PreloaderMain()
         {
-            if (UnityPreloader.ConfigApplyRuntimePatches.Value)
+            try
             {
-                XTermFix.Apply();
-                ConsoleSetOutFix.Apply();
-            }
+                if (UnityPreloader.ConfigApplyRuntimePatches.Value)
+                {
+                    XTermFix.Apply();
+                    ConsoleSetOutFix.Apply();
+                }
 
-            UnityPreloader.Run();
+                UnityPreloader.Run();
+            }
+            catch (Exception e) when (e is MissingMemberException or TypeLoadException)
+            {
+                throw new Exception("\nA reflection error has occurred.\n" +
+                              "This is typically caused by one of the following reasons:\n" +
+                              "1. The game had stripped managed assemblies.\n" +
+                              "See https://hackmd.io/@ghorsington/rJuLdZTzK for how to check and deal with this.\n" +
+                              "2. The game loads a module that is also used by BepInEx.\n" +
+                              "Check for 0Harmony.dll in the game's data directory and rename it if it exists.\n", e);
+            }
         }
 
         private static Assembly LocalResolve(object sender, ResolveEventArgs args)


### PR DESCRIPTION
## Description
Output a hint for troubleshooting when the crash occurred is suspected to be caused by stripped assemblies.

A wrapped exception is used because Mono's Console could be affected by a bug and we are unable to patch that either due to the lack of reflection support.

## Motivation and Context
The installation docs didn't mention these errors. This error message will guide users who read the error log to perform the correct action.

## How Has This Been Tested?
Tested with a game that has a conflicting 0Harmony.dll (cause 2).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- N/A My change requires a change to the documentation.
- N/A I have updated the documentation accordingly.
