### PR TITLE
CI: Emphasize architecture of game instead of OS

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -285,23 +285,23 @@ Task("Pack")
                 ["artifacts"] = new Dictionary<string, object>[] {
                     new() {
                         ["file"] = $"BepInEx_UnityMono_x64{commitPrefix}{buildVersion}.zip",
-                        ["description"] = "BepInEx Unity Mono for Windows x64 machines"
+                        ["description"] = "BepInEx Unity Mono for Windows x64 games"
                     },
                     new() {
                         ["file"] = $"BepInEx_UnityMono_x86{commitPrefix}{buildVersion}.zip",
-                        ["description"] = "BepInEx Unity Mono for Windows x86 machines"
+                        ["description"] = "BepInEx Unity Mono for Windows x86 games"
                     },
                     new() {
                         ["file"] = $"BepInEx_UnityMono_unix{commitPrefix}{buildVersion}.zip",
-                        ["description"] = "BepInEx Unity Mono for Unix machines with GCC (Linux, MacOS)"
+                        ["description"] = "BepInEx Unity Mono for Unix games using GCC (Linux, MacOS)"
                     },
                     new() {
                         ["file"] = $"BepInEx_UnityIL2CPP_x64{commitPrefix}{buildVersion}.zip",
-                        ["description"] = "BepInEx Unity IL2CPP for Windows x64 machines"
+                        ["description"] = "BepInEx Unity IL2CPP for Windows x64 games"
                     },
                     new() {
                         ["file"] = $"BepInEx_UnityIL2CPP_x86{commitPrefix}{buildVersion}.zip",
-                        ["description"] = "BepInEx Unity IL2CPP for Windows x86 machines"
+                        ["description"] = "BepInEx Unity IL2CPP for Windows x86 games"
                     },
                     new() {
                         ["file"] = $"BepInEx_NetLauncher{commitPrefix}{buildVersion}.zip",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The current wording on the download page states that the architecture of the OS (32 or
64-bit) is leading for which version of BepInEx to download. This
however should be the architecture for which the game is built, as you
can run 32-bit Windows games on 64-bit Windows systems and need the
32-bit version of BepInEx in this case.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I helped an user today who was very confused about why his installation of BepInEx for a 32-bit game was not working. He used 64-bit Windows, so he downloaded the 64-bit version as instructed by the download page. It took a few attempts to convince him to download the 32-bit version. This hopefully reduces the amount of new souls that download the wrong version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has not been tested, as I don't have access to the CI environment. I hope that editing the strings in this build script does not make other parts fall over.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Maybe there is a way to migrate the current builds over to the new wording?