### PR TITLE
[Il2Cpp] Use UnityVersionHandler's Size Providers in Harmony Backend

### DIFF
--- a/BepInEx.IL2CPP/Hook/IL2CPPDetourMethodPatcher.cs
+++ b/BepInEx.IL2CPP/Hook/IL2CPPDetourMethodPatcher.cs
@@ -104,8 +104,8 @@ public unsafe class IL2CPPDetourMethodPatcher : MethodPatcher
             // Create a modified native MethodInfo struct to point towards the trampoline
             modifiedNativeMethodInfo = UnityVersionHandler.NewMethod();
             Buffer.MemoryCopy(originalNativeMethodInfo.Pointer.ToPointer(),
-                              modifiedNativeMethodInfo.Pointer.ToPointer(), modifiedNativeMethodInfo.StructSize,
-                              originalNativeMethodInfo.StructSize);
+                              modifiedNativeMethodInfo.Pointer.ToPointer(), UnityVersionHandler.MethodSize(),
+                              UnityVersionHandler.MethodSize());
             modifiedNativeMethodInfo.MethodPointer = trampolinePtr;
             isValid = true;
         }


### PR DESCRIPTION
## Description
Replaces the old INativeMethodInfoStruct.StructSize with UnityVersionHandler.MethodSize().

## Motivation and Context
INativeMethodInfoStruct.StructSize is planned to be removed in a future update of unhollower in favor of UnityVersionHandler's size providers.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
