### PR TITLE
Change visibility of ConfigEntryBase constructor to `internal protected` to allow for external implementations

### DIFF
--- a/BepInEx.Core/Configuration/ConfigEntryBase.cs
+++ b/BepInEx.Core/Configuration/ConfigEntryBase.cs
@@ -64,7 +64,7 @@ public abstract class ConfigEntryBase
     /// <summary>
     ///     Types of defaultValue and definition.AcceptableValues have to be the same as settingType.
     /// </summary>
-    internal ConfigEntryBase(ConfigFile configFile,
+    internal protected ConfigEntryBase(ConfigFile configFile,
                              ConfigDefinition definition,
                              Type settingType,
                              object defaultValue,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I added `protected` to the access modifiers for the `ConfigEntryBase` constructor

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows for an external assembly to create a type that extends off of `ConfigEntryBase`
Currently, the only constructor is `internal`, which prevents an external assembly from creating a class that derives from it
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I built the project in both debug and release mode.
I replaced the existing `BepInEx.Core.dll` in my install with a new one
Everything seemed normal

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
