### PR TITLE
Add unhollower RegEx rename config option

### DIFF
--- a/BepInEx.IL2CPP/ProxyAssemblyGenerator.cs
+++ b/BepInEx.IL2CPP/ProxyAssemblyGenerator.cs
@@ -6,6 +6,7 @@ using System.IO.Compression;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 using AssemblyUnhollower;
 using BepInEx.Configuration;
 using BepInEx.Logging;
@@ -62,6 +63,15 @@ internal static class ProxyAssemblyGenerator
          .AppendLine("Supports the following placeholders:")
          .AppendLine("{BepInEx} - Path to the BepInEx folder.")
          .AppendLine("{ProcessName} - Name of the current process")
+         .ToString());
+
+    private static readonly ConfigEntry<string> ConfigUnhollowerDeobfuscationRegex = ConfigFile.CoreConfig.Bind(
+     "IL2CPP", "UnhollowerDeobfuscationRegex",
+     string.Empty,
+     new StringBuilder()
+         .AppendLine("The RegEx string to pass to Il2CppAssemblyUnhollower for renaming obfuscated names.")
+         .AppendLine("All types and members matching this RegEx will get a name based on their signature,")
+         .AppendLine("resulting in names that persist after game updates.")
          .ToString());
 
     private static ManualLogSource Il2cppDumperLogger;
@@ -367,7 +377,8 @@ internal static class ProxyAssemblyGenerator
                 Source = sourceAssemblies,
                 OutputDir = Preloader.IL2CPPUnhollowedPath,
                 UnityBaseLibsDir = Directory.Exists(UnityBaseLibsDirectory) ? UnityBaseLibsDirectory : null,
-                NoCopyUnhollowerLibs = true
+                NoCopyUnhollowerLibs = true,
+                ObfuscatedNamesRegex = !string.IsNullOrEmpty(ConfigUnhollowerDeobfuscationRegex.Value) ? new Regex(ConfigUnhollowerDeobfuscationRegex.Value) : null
             };
 
             var renameMapLocation = Path.Combine(Paths.BepInExRootPath, "DeobfuscationMap.csv.gz");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a core config option to the `IL2CPP` section. The option makes it possible to pass a renaming RegEx to Unhollower, which will then rename any type or member that matches the RegEx to a name that's based on the type or member's signature.

## Motivation and Context
Using a renaming RegEx in Unhollower should help with getting more stable type and member names, minimizing plugins breaking when the game updates.

## How Has This Been Tested?
Tested on Windows 10 and Linux with Proton-GE.
Ran BepInEx with a RegEx string specified that is suitable for the game's obfuscated names (`^[A-Z]{11}$` in my case), Unhollower ran as usual but the output now has "de-obfuscated" names.
Created a plugin with some Harmony patches that specifically call those de-obfuscated names, they work fine in-game.

## Screenshots
![SweetNames](https://user-images.githubusercontent.com/4087076/178614515-1d923a2c-56e6-41a1-9ca1-165ede8fcf3d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
