### PR TITLE
fix: handle parameter spread for lts version

### DIFF
--- a/doorstop/run_bepinex.sh
+++ b/doorstop/run_bepinex.sh
@@ -142,4 +142,4 @@ export LD_PRELOAD=$doorstop_libname:$LD_PRELOAD
 export DYLD_LIBRARY_PATH="${doorstop_libs}"
 export DYLD_INSERT_LIBRARIES="${doorstop_libs}/$doorstop_libname"
 
-"${executable_path}" $@
+"${executable_path}" "$@"

--- a/doorstop/run_bepinex.sh
+++ b/doorstop/run_bepinex.sh
@@ -142,4 +142,4 @@ export LD_PRELOAD=$doorstop_libname:$LD_PRELOAD
 export DYLD_LIBRARY_PATH="${doorstop_libs}"
 export DYLD_INSERT_LIBRARIES="${doorstop_libs}/$doorstop_libname"
 
-"${executable_path}"
+"${executable_path}" $@


### PR DESCRIPTION
## Description
Allows the modded game to be ran with parameters from launcher level.
basically it allows to do something like this:
`/bin/sh "/pat/to/game/directory/run_bepinex.sh" "" "-screen-width 1000"` after setting cwd to game directory.
... this `""` works like skipping argument for game executable AND doesn't appear in $@ from game point of view

## Motivation and Context
I am rewriting CastleStory launcher and figured out that this is most likely a mistake in run_bepinex, I don't want to update to 6.x yet - it is fixed there tho (at least looks like so).

## How Has This Been Tested?
I've just run the game from command line and by spawning process from launcher.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] (I guess?) New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [?] My change requires a change to the documentation.
- [?] I have updated the documentation accordingly.

(I can update docs if it is needed ^^)
