### PR TITLE
Add a config option to disable xref and disable it by default on x32

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -58,6 +58,11 @@ internal static class Il2CppInteropManager
          .AppendLine("resulting in names that persist after game updates.")
          .ToString());
 
+    private static readonly ConfigEntry<bool> ScanMethodRefs = ConfigFile.CoreConfig.Bind(
+     "IL2CPP", "ScanMethodRefs",
+     Environment.Is64BitProcess,
+     "If enabled, Il2CppInterop will use xref to find dead methods and generate CallerCount attributes.");
+
     private static readonly ConfigEntry<bool> DumpDummyAssemblies = ConfigFile.CoreConfig.Bind(
      "IL2CPP", "DumpDummyAssemblies",
      false,
@@ -287,7 +292,7 @@ internal static class Il2CppInteropManager
     {
         var opts = new GeneratorOptions
         {
-            GameAssemblyPath = GameAssemblyPath,
+            GameAssemblyPath = ScanMethodRefs.Value ? GameAssemblyPath : null,
             Source = sourceAssemblies,
             OutputDir = IL2CPPInteropAssemblyPath,
             UnityBaseLibsDir = Directory.Exists(UnityBaseLibsDirectory) ? UnityBaseLibsDirectory : null,


### PR DESCRIPTION
Adds a config option for disabling xref so you can do it as a temporary workaround when xref causes crashes.
Also disables xref on x32 by default because its very flaky and doesn't provide correct results there anyway, it could be enabled again if its ever fixed properly on il2cppinterop side.