### PR TITLE
Add an useragent when downloading unity libraries

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -246,6 +246,10 @@ internal static partial class Il2CppInteropManager
             Directory.EnumerateFiles(UnityBaseLibsDirectory, "*.dll").Do(File.Delete);
 
             using var httpClient = new HttpClient();
+            var bepinVersion = Paths.BepInExVersion;
+            var version = new SemanticVersioning.Version(bepinVersion.Major, bepinVersion.Minor, bepinVersion.Patch,
+                                                         bepinVersion.PreRelease);
+            httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd($"BepInEx/{version}");
             using var zipStream = httpClient.GetStreamAsync(source).GetAwaiter().GetResult();
             using var zipArchive = new ZipArchive(zipStream, ZipArchiveMode.Read);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This adds an user agent to the download request, which is configured to be `BepInEx/` + the version of BepInEx in use.

Reporting an OS or pretending to be [an actual browser](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) didn't feel right

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently users in some countries are blocked from downloading unity libs, although they are able to download the libraries using their browser. Because of this I'm assuming that the combination of country and the lack of an user agent is causing the download to fail. Add an user agent identifying us as BepInEx and hope that makes the request less sus.

This hopefully fixes what I've been calling the Kazakhstan problem, as reported by me in April last year: https://discord.com/channels/623153565053222947/624272422295568435/968527472377344070 . This issue doesn't appear frequently, but in support channels we only see the tip of the iceberg. So far I've seen users with issues in Kazakhstan (3), Pakistan (1) and Russia (1). 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- I tested it against the original server => still works
- I tested it against a local cache to verify it actually sets an user agent => see screenshot for a before/after 
- I'm reaching out to a user in one of the affected countries to see if this lets them download from the original server => WIP

## Screenshots (if appropriate):

Http server log of the results of step 2:
![2023-01-24T20:56:22,000477055+01:00](https://user-images.githubusercontent.com/5243971/214395653-d7079dc9-aa48-48cb-a3d7-8d27ce20b4e8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
