### PR TITLE
Don't try to parse the wine version

### DIFF
--- a/BepInEx.Preloader.Core/PlatformUtils.cs
+++ b/BepInEx.Preloader.Core/PlatformUtils.cs
@@ -10,7 +10,7 @@ internal static class PlatformUtils
 {
     public static readonly bool ProcessIs64Bit = IntPtr.Size >= 8;
     public static Version WindowsVersion { get; set; }
-    public static Version WineVersion { get; set; }
+    public static string WineVersion { get; set; }
 
     public static string LinuxArchitecture { get; set; }
     public static string LinuxKernelVersion { get; set; }
@@ -81,7 +81,7 @@ internal static class PlatformUtils
                 {
                     current |= Platform.Wine;
                     var getVersion = wineGetVersion.AsDelegate<GetWineVersionDelegate>();
-                    WineVersion = new Version(getVersion());
+                    WineVersion = getVersion();
                 }
             }
         }


### PR DESCRIPTION
Wine can have versions like `8.0-rc5` which currently crash, we only get it to log it for debugging so just don't try to parse it.