### PR TITLE
Bump Il2CppInterop to v1.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A more comprehensive comparison list of features and compatibility is available 
 #### IL2CPP libraries
 
 - [SamboyCoding/Cpp2IL](https://github.com/SamboyCoding/Cpp2IL) - v2022.0.7.2
-- [BepInEx/Il2CppInterop](https://github.com/BepInEx/Il2CppInterop) - v1.4.1
+- [BepInEx/Il2CppInterop](https://github.com/BepInEx/Il2CppInterop) - v1.4.4
 - [BepInEx/dotnet-runtime](https://github.com/BepInEx/dotnet-runtime) - v6.0.7
 
 ## License

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/BepInEx.Unity.IL2CPP.csproj
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/BepInEx.Unity.IL2CPP.csproj
@@ -15,10 +15,10 @@
     <ItemGroup>
         <PackageReference Include="HarmonyX" Version="2.10.1"/>
         <PackageReference Include="Iced" Version="1.18.0"/>
-        <PackageReference Include="Il2CppInterop.Generator" Version="1.4.1"/>
-        <PackageReference Include="Il2CppInterop.HarmonySupport" Version="1.4.1"/>
+        <PackageReference Include="Il2CppInterop.Generator" Version="1.4.4"/>
+        <PackageReference Include="Il2CppInterop.HarmonySupport" Version="1.4.4"/>
         <PackageReference Include="Il2CppInterop.ReferenceLibs" Version="1.0.0" IncludeAssets="compile" PrivateAssets="all"/>
-        <PackageReference Include="Il2CppInterop.Runtime" Version="1.4.1"/>
+        <PackageReference Include="Il2CppInterop.Runtime" Version="1.4.4"/>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" IncludeAssets="compile" PrivateAssets="all"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" IncludeAssets="compile" PrivateAssets="all"/>
         <PackageReference Include="MonoMod.RuntimeDetour" Version="22.5.1.1"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bumps Il2CppInterop from v1.4.1 to v1.4.4

## Motivation and Context
The current version used by BepInEx is behind on multiple bugfixes that allow newer unity games to run.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
