### PR TITLE
Fix argument count when launched with Steam on Linux

### DIFF
--- a/doorstop/run_bepinex.sh
+++ b/doorstop/run_bepinex.sh
@@ -10,7 +10,7 @@ a="/$0"; a=${a%/*}; a=${a#/}; a=${a:-.}; BASEDIR=$(cd "$a"; pwd -P)
 # ---- EDIT AS NEEDED ------
 
 # EDIT THIS: The name of the executable to run
-# LINUX: This is the name of the Unity game executable 
+# LINUX: This is the name of the Unity game executable
 # MACOS: This is the name of the game app folder, including the .app suffix
 executable_name=""
 
@@ -32,7 +32,7 @@ export DOORSTOP_CORLIB_OVERRIDE_PATH=""
 # Special case: program is launched via Steam
 # In that case rerun the script via their bootstrapper to ensure Steam overlay works
 if [ "$2" = "SteamLaunch" ]; then
-    "$1" "$2" "$3" "$4" "$0" "$5"
+    "$1" "$2" "$3" "$4" "$5" "$6" "$0" "$7"
     exit
 fi
 
@@ -92,7 +92,7 @@ abs_path() {
 }
 
 _readlink() {
-    # relative links with readlink (without -f) do not preserve the path info 
+    # relative links with readlink (without -f) do not preserve the path info
     ab_path="$(abs_path "$1")"
     link="$(readlink "${ab_path}")"
     case $link in
@@ -105,8 +105,8 @@ _readlink() {
 
 resolve_executable_path () {
     e_path="$(abs_path "$1")"
-    
-    while [ -L "${e_path}" ]; do 
+
+    while [ -L "${e_path}" ]; do
         e_path=$(_readlink "${e_path}");
     done
     echo "${e_path}"


### PR DESCRIPTION
## Description
Resolves a recent change (I think) with how Steam on Linux launches applications. I believe the extra `--` arguments are messing up the argument counts for the relaunch. Using the following change I was able to get the game working. Basically added 2 extra arguments and shifted the last argument by 2.

```
if [ "$2" = "SteamLaunch" ]; then
    "$1" "$2" "$3" "$4" "$5" "$6" "$0" "$7"
    exit
fi
```

## Motivation and Context
I had to resolve this issue locally in order to even launch the game on Steam. The changes I made to the game properties in Steam were following [this](https://docs.bepinex.dev/articles/advanced/steam_interop.html) link. This PR resolves issue #559.

## How Has This Been Tested?
I tested this change using the game Ultimate Chicken Horse on Steam on a laptop running Fedora 37.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
