### PR TITLE
Fix argument count when launched with Steam on Linux

### DIFF
--- a/Runtimes/Unity/Doorstop/run_bepinex_il2cpp.sh
+++ b/Runtimes/Unity/Doorstop/run_bepinex_il2cpp.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # BepInEx start script
-# 
+#
 # Run the script to start the game with BepInEx enabled
 #
 # There are two ways to use this script
@@ -65,8 +65,8 @@ corlib_dir="dotnet"
 # Special case: program is launched via Steam
 # In that case rerun the script via their bootstrapper to ensure Steam overlay works
 if [ "$2" = "SteamLaunch" ]; then
-    steam="$1 $2 $3 $4 $0 $5"
-    shift 5
+    steam="$1 $2 $3 $4 $5 $6 $0 $7"
+    shift 7
     $steam "$@"
     exit
 fi
@@ -135,7 +135,7 @@ abs_path() {
 }
 
 _readlink() {
-    # relative links with readlink (without -f) do not preserve the path info 
+    # relative links with readlink (without -f) do not preserve the path info
     ab_path="$(abs_path "$1")"
     link="$(readlink "${ab_path}")"
     case $link in
@@ -148,8 +148,8 @@ _readlink() {
 
 resolve_executable_path () {
     e_path="$(abs_path "$1")"
-    
-    while [ -L "${e_path}" ]; do 
+
+    while [ -L "${e_path}" ]; do
         e_path=$(_readlink "${e_path}");
     done
     echo "${e_path}"

--- a/Runtimes/Unity/Doorstop/run_bepinex_mono.sh
+++ b/Runtimes/Unity/Doorstop/run_bepinex_mono.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # BepInEx start script
-# 
+#
 # Run the script to start the game with BepInEx enabled
 #
 # There are two ways to use this script
@@ -65,8 +65,8 @@ corlib_dir=""
 # Special case: program is launched via Steam
 # In that case rerun the script via their bootstrapper to ensure Steam overlay works
 if [ "$2" = "SteamLaunch" ]; then
-    steam="$1 $2 $3 $4 $0 $5"
-    shift 5
+    steam="$1 $2 $3 $4 $5 $6 $0 $7"
+    shift 7
     $steam "$@"
     exit
 fi
@@ -135,7 +135,7 @@ abs_path() {
 }
 
 _readlink() {
-    # relative links with readlink (without -f) do not preserve the path info 
+    # relative links with readlink (without -f) do not preserve the path info
     ab_path="$(abs_path "$1")"
     link="$(readlink "${ab_path}")"
     case $link in
@@ -148,8 +148,8 @@ _readlink() {
 
 resolve_executable_path () {
     e_path="$(abs_path "$1")"
-    
-    while [ -L "${e_path}" ]; do 
+
+    while [ -L "${e_path}" ]; do
         e_path=$(_readlink "${e_path}");
     done
     echo "${e_path}"


### PR DESCRIPTION
## Description
Resolves a recent change (I think) with how Steam on Linux launches applications. I believe the extra `--` arguments are messing up the argument counts for the relaunch. Using the following change I was able to get the game working. Basically added 2 extra arguments and shifted the last argument by 2.

```
if [ "$2" = "SteamLaunch" ]; then
    steam="$1 $2 $3 $4 $5 $6 $0 $7"
    shift 7
    $steam "$@"
    exit
fi
```

## Motivation and Context
This PR resolves issue #559. See also #562 for the same change on `v5-lts` branch.

## How Has This Been Tested?
I tested this change using the game Ultimate Chicken Horse on Steam on a laptop running Fedora 37.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
