### PR TITLE
- Make BepInEx print the thunderstore manifest.json of a mod when available - DiskLogListener expose the file path that it uses

### DIFF
--- a/BepInEx.Preloader/Preloader.cs
+++ b/BepInEx.Preloader/Preloader.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using BepInEx.Bootstrap;
 using BepInEx.Configuration;
 using BepInEx.Logging;
 using BepInEx.Preloader.Patching;
@@ -46,9 +47,11 @@ namespace BepInEx.Preloader
 
 				Logger.InitializeInternalLoggers();
 				Logger.Sources.Add(TraceLogSource.CreateSource());
-				
+
 				PreloaderLog = new PreloaderConsoleListener();
 				Logger.Listeners.Add(PreloaderLog);
+
+				Chainloader.InitDiskLogging();
 
 				Version version = typeof(Paths).Assembly.GetName().Version;
 

--- a/BepInEx/BepInEx.csproj
+++ b/BepInEx/BepInEx.csproj
@@ -41,6 +41,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+	<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <Reference Include="0Harmony, Version=2.9.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>$(SolutionDir)\packages\HarmonyX.2.9.0\lib\net35\0Harmony.dll</HintPath>
       <Private>True</Private>
@@ -72,6 +73,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Contract\ThunderstoreV1Manifest.cs" />
     <Compile Include="UnityInput.cs" />
     <Compile Include="Configuration\AcceptableValueBase.cs" />
     <Compile Include="Configuration\AcceptableValueList.cs" />

--- a/BepInEx/Bootstrap/Chainloader.cs
+++ b/BepInEx/Bootstrap/Chainloader.cs
@@ -41,8 +41,14 @@ namespace BepInEx.Bootstrap
 			get => Application.unityVersion;
 		}
 
-		// Check above for NoInlining reasoning
-		private static bool IsHeadless
+        internal static void InitDiskLogging()
+        {
+			if (ConfigDiskLogging.Value)
+				Logger.Listeners.Add(new DiskLogListener("LogOutput.log", ConfigDiskConsoleDisplayedLevel.Value, ConfigDiskAppend.Value, ConfigDiskWriteUnityLog.Value));
+		}
+
+        // Check above for NoInlining reasoning
+        private static bool IsHeadless
 		{
 			get
 			{
@@ -118,9 +124,6 @@ namespace BepInEx.Bootstrap
 			}
 
 			Logger.InitializeInternalLoggers();
-
-			if (ConfigDiskLogging.Value)
-				Logger.Listeners.Add(new DiskLogListener("LogOutput.log", ConfigDiskConsoleDisplayedLevel.Value, ConfigDiskAppend.Value, ConfigDiskWriteUnityLog.Value));
 
 			if (!TraceLogSource.IsListening)
 				Logger.Sources.Add(TraceLogSource.CreateSource());

--- a/BepInEx/Bootstrap/Chainloader.cs
+++ b/BepInEx/Bootstrap/Chainloader.cs
@@ -29,13 +29,13 @@ namespace BepInEx.Bootstrap
 
 		private static readonly List<BaseUnityPlugin> _plugins = new List<BaseUnityPlugin>();
 
-		// In some rare cases calling Application.unityVersion seems to cause MissingMethodException
-		// if a preloader patch applies Harmony patch to Chainloader.Initialize.
-		// The issue could be related to BepInEx being compiled against Unity 5.6 version of UnityEngine.dll,
-		// but the issue is apparently present with both official Harmony and HarmonyX
-		// We specifically prevent inlining to prevent early resolving
-		// TODO: Figure out better version obtaining mechanism (e.g. from globalmanagers)
-		private static string UnityVersion
+        // In some rare cases calling Application.unityVersion seems to cause MissingMethodException
+        // if a preloader patch applies Harmony patch to Chainloader.Initialize.
+        // The issue could be related to BepInEx being compiled against Unity 5.6 version of UnityEngine.dll,
+        // but the issue is apparently present with both official Harmony and HarmonyX
+        // We specifically prevent inlining to prevent early resolving
+        // TODO: Figure out better version obtaining mechanism (e.g. from globalmanagers)
+        private static string UnityVersion
 		{
 			[MethodImpl(MethodImplOptions.NoInlining)]
 			get => Application.unityVersion;
@@ -44,8 +44,10 @@ namespace BepInEx.Bootstrap
         internal static void InitDiskLogging()
         {
 			if (ConfigDiskLogging.Value)
-				Logger.Listeners.Add(new DiskLogListener("LogOutput.log", ConfigDiskConsoleDisplayedLevel.Value, ConfigDiskAppend.Value, ConfigDiskWriteUnityLog.Value));
-		}
+			{
+                Logger.Listeners.Add(new DiskLogListener("LogOutput.log", ConfigDiskConsoleDisplayedLevel.Value, ConfigDiskAppend.Value, ConfigDiskWriteUnityLog.Value));
+            }
+        }
 
         // Check above for NoInlining reasoning
         private static bool IsHeadless
@@ -163,12 +165,16 @@ namespace BepInEx.Bootstrap
 
 			// Temporarily disable the console log listener (if there is one from preloader) as we replay the preloader logs
 			var logListener = Logger.Listeners.FirstOrDefault(logger => logger is ConsoleLogListener);
+			var diskLogListener = Logger.Listeners.FirstOrDefault(logger => logger is DiskLogListener);
 
 			if (logListener != null)
 				Logger.Listeners.Remove(logListener);
 
-			// Write preloader log events if there are any, including the original log source name
-			var preloaderLogSource = Logger.CreateLogSource("Preloader");
+			if (diskLogListener != null)
+				Logger.Listeners.Remove(diskLogListener);
+
+            // Write preloader log events if there are any, including the original log source name
+            var preloaderLogSource = Logger.CreateLogSource("Preloader");
 
 			foreach (var preloaderLogEvent in preloaderLogEvents)
 				Logger.InternalLogEvent(preloaderLogSource, preloaderLogEvent);
@@ -177,9 +183,12 @@ namespace BepInEx.Bootstrap
 
 			Logger.Listeners.Remove(unityLogger);
 
-			if (logListener != null)
+            if (diskLogListener != null)
+                Logger.Listeners.Add(diskLogListener);
+
+            if (logListener != null)
 				Logger.Listeners.Add(logListener);
-		}
+        }
 
 		private static Regex allowedGuidRegex { get; } = new Regex(@"^[a-zA-Z0-9\._\-]+$");
 

--- a/BepInEx/Bootstrap/Chainloader.cs
+++ b/BepInEx/Bootstrap/Chainloader.cs
@@ -499,10 +499,11 @@ namespace BepInEx.Bootstrap
 					var thunderstoreManifestV1 = JsonConvert.DeserializeObject<ThunderstoreManifestV1>(File.ReadAllText(manifestPath));
 
 					const string InvalidTeamName = "|";
-					var team = InvalidTeamName;
-					var directoryName = new DirectoryInfo(Path.GetDirectoryName(manifestPath)).Name;
 					const char separator = '-';
 					var teamNameDelimiter = separator + thunderstoreManifestV1.Name;
+
+					var team = InvalidTeamName;
+					var directoryName = new DirectoryInfo(Path.GetDirectoryName(manifestPath)).Name;
 					if (directoryName.Contains(teamNameDelimiter))
 					{
 						team = directoryName.Split(new string[] { teamNameDelimiter }, StringSplitOptions.RemoveEmptyEntries)[0];

--- a/BepInEx/Contract/ThunderstoreV1Manifest.cs
+++ b/BepInEx/Contract/ThunderstoreV1Manifest.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace BepInEx
+{
+    internal class ThunderstoreManifestV1
+    {
+        [JsonProperty("name")]
+        internal string Name { get; set; }
+
+        [JsonProperty("version_number")]
+        internal string VersionNumber { get; set; }
+
+        [JsonProperty("website_url")]
+        internal Uri WebsiteUrl { get; set; }
+
+        [JsonProperty("description")]
+        internal string Description { get; set; }
+
+        [JsonProperty("dependencies")]
+        internal List<string> Dependencies { get; set; }
+    }
+}

--- a/BepInEx/Logging/DiskLogListener.cs
+++ b/BepInEx/Logging/DiskLogListener.cs
@@ -20,6 +20,11 @@ namespace BepInEx.Logging
 		public TextWriter LogWriter { get; protected set; }
 
 		/// <summary>
+		/// Full path to the used disk file.
+		/// </summary>
+		public string FileFullPath { get; }
+
+		/// <summary>
 		/// Timer for flushing the logs to a file.
 		/// </summary>
 		public Timer FlushTimer { get; protected set; }
@@ -44,8 +49,8 @@ namespace BepInEx.Logging
 			int counter = 1;
 
 			FileStream fileStream;
-
-			while (!Utility.TryOpenFileStream(Path.Combine(Paths.BepInExRootPath, localPath), appendLog ? FileMode.Append : FileMode.Create, out fileStream, share: FileShare.Read, access: FileAccess.Write))
+			var fullPath = Path.Combine(Paths.BepInExRootPath, localPath);
+			while (!Utility.TryOpenFileStream(fullPath, appendLog ? FileMode.Append : FileMode.Create, out fileStream, share: FileShare.Read, access: FileAccess.Write))
 			{
 				if (counter == 5)
 				{
@@ -56,11 +61,12 @@ namespace BepInEx.Logging
 
 				Logger.LogWarning($"Couldn't open log file '{localPath}' for writing, trying another...");
 
-				localPath = $"LogOutput.log.{counter++}";
+				localPath = $"{localPath}.{counter++}";
+				fullPath = Path.Combine(Paths.BepInExRootPath, localPath);
 			}
 
 			LogWriter = TextWriter.Synchronized(new StreamWriter(fileStream, Utility.UTF8NoBom));
-
+			FileFullPath = fullPath;
 
 			FlushTimer = new Timer(o => { LogWriter?.Flush(); }, null, 2000, 2000);
 		}


### PR DESCRIPTION
First change makes debugging much easier
Second change is needed for BepInExGUI purposes