### PR TITLE
Not Download Unity Base Libraries If LatestUnityVersion==CurrentUnityVersion

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -89,6 +89,8 @@ internal static partial class Il2CppInteropManager
 
     private static string HashPath => Path.Combine(IL2CPPInteropAssemblyPath, "assembly-hash.txt");
 
+    private static string LatestUnityVersionPath => Path.Combine(UnityBaseLibsDirectory, "latest-unity-version.txt");
+
     private static string UnityBaseLibsDirectory => Path.Combine(Paths.BepInExRootPath, "unity-libs");
 
     internal static string IL2CPPInteropAssemblyPath => Path.Combine(Paths.BepInExRootPath, "interop");
@@ -120,14 +122,6 @@ internal static partial class Il2CppInteropManager
         }
 
         HashFile(md5, GameAssemblyPath);
-
-        if (Directory.Exists(UnityBaseLibsDirectory))
-            foreach (var file in Directory.EnumerateFiles(UnityBaseLibsDirectory, "*.dll",
-                                                          SearchOption.TopDirectoryOnly))
-            {
-                HashString(md5, Path.GetFileName(file));
-                HashFile(md5, file);
-            }
 
         // Hash some common dependencies as they can affect output
         HashString(md5, typeof(InteropAssemblyGenerator).Assembly.GetName().Version.ToString());
@@ -189,10 +183,10 @@ internal static partial class Il2CppInteropManager
 
         var unityVersion = UnityInfo.Version;
         Il2CppInteropRuntime.Create(new RuntimeConfiguration
-                            {
-                                UnityVersion = new Version(unityVersion.Major, unityVersion.Minor, unityVersion.Build),
-                                DetourProvider = new Il2CppInteropDetourProvider()
-                            })
+        {
+            UnityVersion = new Version(unityVersion.Major, unityVersion.Minor, unityVersion.Build),
+            DetourProvider = new Il2CppInteropDetourProvider()
+        })
                             .AddLogger(interopLogger)
                             .AddHarmonySupport()
                             .Start();
@@ -231,12 +225,29 @@ internal static partial class Il2CppInteropManager
         }
     }
 
+    private static bool CheckIfDownloadRequired()
+    {
+        if (!Directory.Exists(UnityBaseLibsDirectory))
+            return true;
+
+        if (!File.Exists(LatestUnityVersionPath))
+            return true;
+
+        var unityVersion = UnityInfo.Version;
+        if (new Version(unityVersion.Major, unityVersion.Minor, unityVersion.Build) != Version.Parse(File.ReadAllText(LatestUnityVersionPath)))
+            return true;
+
+        return false;
+    }
     private static void DownloadUnityAssemblies()
     {
+        if (!CheckIfDownloadRequired())
+            return;
         var unityVersion = UnityInfo.Version;
+        var VERSION = $"{unityVersion.Major}.{unityVersion.Minor}.{unityVersion.Build}";
         var source =
             UnityBaseLibrariesSource.Value.Replace("{VERSION}",
-                                                   $"{unityVersion.Major}.{unityVersion.Minor}.{unityVersion.Build}");
+                                                   VERSION);
 
         if (!string.IsNullOrEmpty(source))
         {
@@ -249,6 +260,7 @@ internal static partial class Il2CppInteropManager
             using var zipStream = httpClient.GetStreamAsync(source).GetAwaiter().GetResult();
             using var zipArchive = new ZipArchive(zipStream, ZipArchiveMode.Read);
 
+            File.WriteAllText(LatestUnityVersionPath, VERSION);
             Logger.LogMessage("Extracting downloaded unity base libraries");
             zipArchive.ExtractToDirectory(UnityBaseLibsDirectory);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Not Download Unity Base Libraries If LatestUnityVersion==CurrentUnityVersion
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sometime,when we may want to not download Unity Base Libraries the current Unity version when it is the same as the last Unity version
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project...Maybe?
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
