### PR TITLE
run_bepinex*.sh: self-relaunch improvements

### DIFF
--- a/Runtimes/Unity/Doorstop/run_bepinex_il2cpp.sh
+++ b/Runtimes/Unity/Doorstop/run_bepinex_il2cpp.sh
@@ -67,8 +67,7 @@ corlib_dir="dotnet"
 if [ "$2" = "SteamLaunch" ]; then
     steam="$1 $2 $3 $4 $5 $6 $0 $7"
     shift 7
-    $steam "$@"
-    exit
+    exec $steam "$@"
 fi
 
 # Handle first param being executable name

--- a/Runtimes/Unity/Doorstop/run_bepinex_il2cpp.sh
+++ b/Runtimes/Unity/Doorstop/run_bepinex_il2cpp.sh
@@ -65,9 +65,28 @@ corlib_dir="dotnet"
 # Special case: program is launched via Steam
 # In that case rerun the script via their bootstrapper to ensure Steam overlay works
 if [ "$2" = "SteamLaunch" ]; then
-    steam="$1 $2 $3 $4 $5 $6 $0 $7"
-    shift 7
-    exec $steam "$@"
+    # Conceptually: exec "$1" "$2" "$3" "$4" "$0" "rest of $@"
+    # But newer versions of Steam interleave the $1..$4 with some "--" arguments, so preserve them as well
+    # Bash has array subscripting, but POSIX sh doesn't, so avoid it
+    to_rotate=4
+    rotated=0
+    while [ $((to_rotate-=1)) -ge 0 ]; do
+        while [ "z$1" = "z--" ]; do
+            set -- "$@" "$1"
+            shift
+            rotated=$((rotated+1))
+        done
+        set -- "$@" "$1"
+        shift
+        rotated=$((rotated+1))
+    done
+    to_rotate=$(($# - rotated))
+    set -- "$@" "$0"
+    while [ $((to_rotate-=1)) -ge 0 ]; do
+        set -- "$@" "$1"
+        shift
+    done
+    exec "$@"
 fi
 
 # Handle first param being executable name

--- a/Runtimes/Unity/Doorstop/run_bepinex_mono.sh
+++ b/Runtimes/Unity/Doorstop/run_bepinex_mono.sh
@@ -67,8 +67,7 @@ corlib_dir=""
 if [ "$2" = "SteamLaunch" ]; then
     steam="$1 $2 $3 $4 $5 $6 $0 $7"
     shift 7
-    $steam "$@"
-    exit
+    exec $steam "$@"
 fi
 
 # Handle first param being executable name

--- a/Runtimes/Unity/Doorstop/run_bepinex_mono.sh
+++ b/Runtimes/Unity/Doorstop/run_bepinex_mono.sh
@@ -65,9 +65,28 @@ corlib_dir=""
 # Special case: program is launched via Steam
 # In that case rerun the script via their bootstrapper to ensure Steam overlay works
 if [ "$2" = "SteamLaunch" ]; then
-    steam="$1 $2 $3 $4 $5 $6 $0 $7"
-    shift 7
-    exec $steam "$@"
+    # Conceptually: exec "$1" "$2" "$3" "$4" "$0" "rest of $@"
+    # But newer versions of Steam interleave the $1..$4 with some "--" arguments, so preserve them as well
+    # Bash has array subscripting, but POSIX sh doesn't, so avoid it
+    to_rotate=4
+    rotated=0
+    while [ $((to_rotate-=1)) -ge 0 ]; do
+        while [ "z$1" = "z--" ]; do
+            set -- "$@" "$1"
+            shift
+            rotated=$((rotated+1))
+        done
+        set -- "$@" "$1"
+        shift
+        rotated=$((rotated+1))
+    done
+    to_rotate=$(($# - rotated))
+    set -- "$@" "$0"
+    while [ $((to_rotate-=1)) -ge 0 ]; do
+        set -- "$@" "$1"
+        shift
+    done
+    exec "$@"
 fi
 
 # Handle first param being executable name


### PR DESCRIPTION
This targets master. v5-lts version: #693

## Description

This modifies `run_bepinex*.sh` to support both old and new versions of Steam, as well as to support paths that contain spaces (which were supported in v5-lts but not in master).

An additional, simple fix for a generic shell-script issue is also included.

## Motivation and Context

Recently, Steam apparently changed the way it executes the game, inserting `--` arguments where they didn’t exist before. So #562 and #563 modified `run_bepinex*.sh` to match this change by hardcoding the two added arguments. As noted in https://github.com/BepInEx/BepInEx/pull/562#pullrequestreview-1548351028, this presumably made it impossible to run BepInEx in older versions of Steam.

This pull request teaches the code in `run_bepinex*.sh` to handle the `--` arguments in a special way, achieving the desired effect both in old Steam where they’re absent and in new Steam where they’re present.

Further, the shell script now uses `exec` instead of `call; exit` (thus allowing, for example, killed-by-signal status to be passed through to the invoker in case it matters, not to mention a minor efficiency improvement).

## How Has This Been Tested?

I’ve tested the new code in an isolated shell script (in openSUSE’s bash 4.4.23 and Ubuntu’s dash 0.5.11, both invoked as `sh`), but I have **_not_** tested an actual Steam setup.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (This is probably irrelevant for the shell scripts? But I tried to make it consistent with the other code in the same files.)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
