### PR TITLE
Normalize EOL for .sln (CRLF) and .cs, .sh (LF)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+*.cs text eol=lf
+*.sh text eol=lf
+# Declare files that will always have CRLF line endings on checkout.
+*.sln text eol=crlf


### PR DESCRIPTION
## Description
This PR adds a `.gitattributes` file to the v5-lts branch, specifically the same one that is on master, but tbh I'm only concerned about line 3:

```
*.sh text eol=lf
```

## Motivation and Context
While running tests on BepInEx on macOS (I maintain a BepInEx pack for Subnautica and also Subnautica: Below Zero), I discovered that the `run_bepinex.sh` script distributed with v5.4.22 has CRLF line endings, which prevents it from working. Simply converting the EOL to LF immediately resolved the issue. The issue isn't present in v5.4.21, and the changelog of 5.4.22 indicates that `run_bepinex.sh` was modified in the update.

Presumed cause of the issue is that 5.4.22 was built on a Windows machine, which checked out the `run_bepinex.sh` script with CRLF line endings, as there is no normalization set by a `.gitattributes` file on the v5-lts branch.

## How Has This Been Tested?
Downloaded the `run_bepinex.sh` script from my fork after making the change and it's LF. Same on a Windows machine, which is ideal.

However, it's worth noting that I ALSO tested this on your v5-lts branch, and both on macOS and Windows it seems to download with the correct LF EOL, so I honestly have no idea how one with CRLF EOL ended up in the unix release build? (I triple checked, the one in BepInEx_unix_5.4.22.zip is CRLF, and attempting to run it without fixing the EOL causes errors, which is what led me down this rabbit hole).

Whoever looks into this, you'll probably want to make 100% sure that whatever build process you have for releases takes EOL into account. Hopefully just adding this `.gitattributes` fixes that for you, but unfortunately, I have no way to test your release pipeline.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
