### PR TITLE
Fix netfx & netcore build targets, and add target framework variants

### DIFF
--- a/Runtimes/NET/BepInEx.NET.CoreCLR/BepInEx.NET.CoreCLR.csproj
+++ b/Runtimes/NET/BepInEx.NET.CoreCLR/BepInEx.NET.CoreCLR.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Description>BepInEx support library for CoreCLR games</Description>
-        <TargetFrameworks>netcoreapp3.1;net6</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
         <OutputPath>$(BuildDir)/NET.CoreCLR</OutputPath>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>

--- a/Runtimes/NET/BepInEx.NET.CoreCLR/BepInEx.NET.CoreCLR.csproj
+++ b/Runtimes/NET/BepInEx.NET.CoreCLR/BepInEx.NET.CoreCLR.csproj
@@ -2,10 +2,10 @@
 
     <PropertyGroup>
         <Description>BepInEx support library for CoreCLR games</Description>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net6</TargetFrameworks>
         <OutputPath>$(BuildDir)/NET.CoreCLR</OutputPath>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Runtimes/NET/BepInEx.NET.Framework.Launcher/BepInEx.NET.Framework.Launcher.csproj
+++ b/Runtimes/NET/BepInEx.NET.Framework.Launcher/BepInEx.NET.Framework.Launcher.csproj
@@ -2,9 +2,9 @@
     <PropertyGroup>
         <Description>BepInEx support library for .NET Framework games</Description>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net452</TargetFramework>
+        <TargetFrameworks>net40;net452</TargetFrameworks>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
         <PlatformTarget>x86</PlatformTarget>
         <OutputPath>$(BuildDir)/NET.Framework</OutputPath>
     </PropertyGroup>
@@ -16,6 +16,7 @@
     <ItemGroup>
         <PackageReference Include="HarmonyX" Version="2.10.1"/>
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All"/>
+        <PackageReference Include="MonoMod.RuntimeDetour" Version="22.5.1.1" />
     </ItemGroup>
     <Import Project="..\BepInEx.NET.Shared\BepInEx.NET.Shared.projitems" Label="Shared"/>
 </Project>

--- a/Runtimes/NET/BepInEx.NET.Framework.Launcher/BepInEx.NET.Framework.Launcher.csproj
+++ b/Runtimes/NET/BepInEx.NET.Framework.Launcher/BepInEx.NET.Framework.Launcher.csproj
@@ -16,7 +16,6 @@
     <ItemGroup>
         <PackageReference Include="HarmonyX" Version="2.10.1"/>
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All"/>
-        <PackageReference Include="MonoMod.RuntimeDetour" Version="22.5.1.1" />
     </ItemGroup>
     <Import Project="..\BepInEx.NET.Shared\BepInEx.NET.Shared.projitems" Label="Shared"/>
 </Project>

--- a/Runtimes/NET/BepInEx.NET.Shared/BepInEx.NET.Shared.shproj
+++ b/Runtimes/NET/BepInEx.NET.Shared/BepInEx.NET.Shared.shproj
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup Label="Globals">
-        <ProjectGuid>067bcc8c-fc25-4929-b4f4-c6a5a7496994</ProjectGuid>
-        <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
-    </PropertyGroup>
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
-    <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props"/>
-    <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props"/>
-    <PropertyGroup/>
-    <Import Project="BepInEx.NetLauncher.Shared.projitems" Label="Shared"/>
-    <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets"/>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>067bcc8c-fc25-4929-b4f4-c6a5a7496994</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <ItemGroup>
+    <Compile Include="SharedEntrypoint.cs" />
+  </ItemGroup>
+  <Import Project="BepInEx.NetLauncher.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
 </Project>

--- a/Runtimes/NET/BepInEx.NET.Shared/BepInEx.NET.Shared.shproj
+++ b/Runtimes/NET/BepInEx.NET.Shared/BepInEx.NET.Shared.shproj
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Label="Globals">
-    <ProjectGuid>067bcc8c-fc25-4929-b4f4-c6a5a7496994</ProjectGuid>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
-  </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
-  <PropertyGroup />
-  <ItemGroup>
-    <Compile Include="SharedEntrypoint.cs" />
-  </ItemGroup>
-  <Import Project="BepInEx.NetLauncher.Shared.projitems" Label="Shared" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+    <PropertyGroup Label="Globals">
+        <ProjectGuid>067bcc8c-fc25-4929-b4f4-c6a5a7496994</ProjectGuid>
+        <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    </PropertyGroup>
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+    <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+    <PropertyGroup />
+    <ItemGroup>
+        <Compile Include="SharedEntrypoint.cs" />
+    </ItemGroup>
+    <Import Project="BepInEx.NetLauncher.Shared.projitems" Label="Shared" />
+    <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
 </Project>

--- a/build/DistributionTarget.cs
+++ b/build/DistributionTarget.cs
@@ -1,12 +1,35 @@
-﻿using System;
+using System;
 
-readonly record struct DistributionTarget(string DistributionIdentifier, string RuntimeIndentifier)
+readonly struct DistributionTarget
 {
-    public readonly string Arch = RuntimeIndentifier.Split('-')[1];
-    public readonly string Engine = DistributionIdentifier.Split('.')[0];
-    public readonly string Os = RuntimeIndentifier.Split('-')[0];
-    public readonly string Runtime = DistributionIdentifier.Split('.')[1];
-    public readonly string Target = $"{DistributionIdentifier}-{RuntimeIndentifier}";
+    public DistributionTarget(string distributionIdentifier, string runtimeIdentifier)
+    {
+        DistributionIdentifier = distributionIdentifier;
+        RuntimeIdentifier = runtimeIdentifier;
+        FrameworkTarget = null;
+
+        Os = RuntimeIdentifier.Split('-')[0];
+        Arch = RuntimeIdentifier.Split('-')[1];
+        Engine = DistributionIdentifier.Split('.')[0];
+        Runtime = DistributionIdentifier.Split('.')[1];
+        Target = $"{DistributionIdentifier}-{RuntimeIdentifier}";
+    }
+
+    public DistributionTarget(string distributionIdentifier, string runtimeIdentifier, string frameworkTarget) : this(distributionIdentifier, runtimeIdentifier)
+    {
+        FrameworkTarget = frameworkTarget;
+        Target = $"{DistributionIdentifier}-{FrameworkTarget}-{RuntimeIdentifier}";
+    }
+
+    public readonly string DistributionIdentifier;
+    public readonly string RuntimeIdentifier;
+    public readonly string FrameworkTarget;
+
+    public readonly string Arch;
+    public readonly string Engine;
+    public readonly string Os;
+    public readonly string Runtime;
+    public readonly string Target;
 
     public string ClearOsName => Os switch
     {

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -50,8 +50,10 @@ public class BuildContext : FrostingContext
         new("Unity.IL2CPP", "win-x64"),
         new("Unity.IL2CPP", "linux-x64"),
         new("Unity.IL2CPP", "macos-x64"),
-        new("NET.Framework", "win-x64"),
-        new("NET.CoreCLR", "win-x64")
+        new("NET.Framework", "win-x86", "net40"),
+        new("NET.Framework", "win-x86", "net452"),
+        new("NET.CoreCLR", "win-x64", "netcoreapp3.1"),
+        new("NET.CoreCLR", "win-x64", "net6")
     };
 
 
@@ -241,8 +243,12 @@ public sealed class MakeDistTask : FrostingTask<BuildContext>
             ctx.CreateDirectory(bepInExDir.Combine("patchers"));
 
             File.WriteAllText(targetDir.CombineWithFilePath("changelog.txt").FullPath, changelog);
-            foreach (var filePath in ctx.GetFiles(ctx.OutputDirectory.Combine(dist.DistributionIdentifier)
-                                                     .Combine("*.*").FullPath))
+
+            var sourceDirectory = ctx.OutputDirectory.Combine(dist.DistributionIdentifier);
+            if (dist.FrameworkTarget != null)
+                sourceDirectory = sourceDirectory.Combine(dist.FrameworkTarget);
+
+            foreach (var filePath in ctx.GetFiles(sourceDirectory.Combine("*.*").FullPath))
                 ctx.CopyFileToDirectory(filePath, bepInExCoreDir);
 
             if (dist.Engine == "Unity")
@@ -269,21 +275,24 @@ public sealed class MakeDistTask : FrostingTask<BuildContext>
                 {
                     ctx.CopyFile(ctx.CacheDirectory.Combine("dobby").Combine($"dobby_{dist.Os}").CombineWithFilePath($"{dist.DllPrefix}dobby_{dist.Arch}.{dist.DllExtension}"),
                                  bepInExCoreDir.CombineWithFilePath($"{dist.DllPrefix}dobby.{dist.DllExtension}"));
-                    ctx.CopyDirectory(ctx.CacheDirectory.Combine("dotnet").Combine(dist.RuntimeIndentifier),
+                    ctx.CopyDirectory(ctx.CacheDirectory.Combine("dotnet").Combine(dist.RuntimeIdentifier),
                                       targetDir.Combine("dotnet"));
                 }
             }
-
-            if (dist.DistributionIdentifier == "NET.Framework")
+            else if (dist.Engine == "NET")
             {
-                ctx.DeleteFile(bepInExCoreDir.CombineWithFilePath("BepInEx.NET.Framework.Launcher.exe.config"));
-                foreach (var filePath in ctx.GetFiles(bepInExCoreDir.Combine("BepInEx.NET.*").FullPath))
-                    ctx.MoveFileToDirectory(filePath, targetDir);
-            }
+                if (dist.Runtime == "Framework")
+                {
+                    ctx.DeleteFile(bepInExCoreDir.CombineWithFilePath("BepInEx.NET.Framework.Launcher.exe.config"));
 
-            if (dist.DistributionIdentifier == "NET.CoreCLR")
-                foreach (var filePath in ctx.GetFiles(bepInExCoreDir.Combine("BepInEx.NET.CoreCLR.*").FullPath))
-                    ctx.MoveFileToDirectory(filePath, targetDir);
+                    ctx.MoveFileToDirectory(bepInExCoreDir.CombineWithFilePath("BepInEx.NET.Framework.Launcher.exe"), targetDir);
+                }
+                else if (dist.Runtime == "CoreCLR")
+                {
+                    foreach (var filePath in ctx.GetFiles(bepInExCoreDir.Combine("BepInEx.NET.CoreCLR.*").FullPath))
+                        ctx.MoveFileToDirectory(filePath, targetDir);
+                }
+            }
         }
     }
 }

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -356,7 +356,7 @@ public sealed class PublishTask : FrostingTask<BuildContext>
                                           {
                                               ["file"] = $"BepInEx-{d.Target}-{ctx.BuildPackageVersion}.zip",
                                               ["description"] =
-                                                  $"BepInEx {d.Engine} ({d.Runtime}) for {d.ClearOsName} ({d.Arch}) games"
+                                                  $"BepInEx {d.Engine} ({d.Runtime}{(d.FrameworkTarget == null ? "" : " " + d.FrameworkTarget)}) for {d.ClearOsName} ({d.Arch}) games"
                                           }).ToArray()
                                       });
     }

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -53,7 +53,7 @@ public class BuildContext : FrostingContext
         new("NET.Framework", "win-x86", "net40"),
         new("NET.Framework", "win-x86", "net452"),
         new("NET.CoreCLR", "win-x64", "netcoreapp3.1"),
-        new("NET.CoreCLR", "win-x64", "net6")
+        new("NET.CoreCLR", "win-x64", "net6.0")
     };
 
 


### PR DESCRIPTION
## Description
Marks NetFX builds as x86, restructures their outputs correctly and adds variants for:
- NetFX v4.0
- NetFX v4.5.2
- NET Core 3.1
- NET 6.0

## Motivation and Context
NetFX and NETCore builds were never widely used and as a result have been broken unnoticed. This adds support for variants which is something I've always wanted to do, and is basically a requirement for any more features to be added in this BepInEx target.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran build with target `Publish`, tested the final .zip files and they work as-is in XNA games I've tested.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
