### PR TITLE
Fix manager GameObject not having a name

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Utils/Il2CppUtils.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Utils/Il2CppUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Il2CppInterop.Runtime;
 using Il2CppInterop.Runtime.Injection;
 using Il2CppInterop.Runtime.InteropTypes;
@@ -14,7 +14,7 @@ internal static class Il2CppUtils
     public static Il2CppObjectBase AddComponent(Type t)
     {
         if (managerGo == null)
-            managerGo = new GameObject { hideFlags = HideFlags.HideAndDontSave };
+            managerGo = new GameObject { hideFlags = HideFlags.HideAndDontSave, name = "BepInEx_Manager" };
 
         if (!ClassInjector.IsTypeRegisteredInIl2Cpp(t))
             ClassInjector.RegisterTypeInIl2Cpp(t);


### PR DESCRIPTION
For some reason the manager GameObject has no name set, so it appears as "New Game Object" whenever a plugin uses `BasePlugin.AddComponent`.

In BepInEx 5 and older it was always named "BepInEx_Manager", so I think this is a bug.

Tested, works fine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
