### PR TITLE
Ubisoft+ IL2CPP Support. They bundle two different EXE/GameAssembly files for retail and subscription versions.

### DIFF
--- a/BepInEx.Core/Paths.cs
+++ b/BepInEx.Core/Paths.cs
@@ -1,8 +1,10 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
 using MonoMod.Utils;
-using SemanticVersioning;
+using Version = SemanticVersioning.Version;
 
 namespace BepInEx;
 
@@ -11,6 +13,12 @@ namespace BepInEx;
 /// </summary>
 public static class Paths
 {
+
+    /// <summary>
+    ///     Whether the current environment is Ubisoft Plus. Value is set in <see cref="UbisoftPlusDetected"/>.
+    /// </summary>
+    private static bool UbisoftPlus { get; set; }
+
     // TODO: Why is this in Paths?
     /// <summary>
     ///    BepInEx version.
@@ -86,12 +94,50 @@ public static class Paths
     /// <summary>
     ///     The name of the currently executing process.
     /// </summary>
-    public static string ProcessName { get; private set; }
+    public static string ProcessName { get; internal set; }
 
     /// <summary>
     ///     List of directories from where Mono will search assemblies before assembly resolving is invoked.
     /// </summary>
     public static string[] DllSearchPaths { get; private set; }
+
+    
+    /// <summary>
+    /// Retrieves the subject name of the signer from a digital certificate of a signed file.
+    /// </summary>
+    /// <param name="filePath">The path to the signed file from which to extract the certificate information.</param>
+    /// <returns>
+    /// The subject name of the signer if the file is signed and a certificate is found; otherwise, null.
+    /// </returns>
+    private static string GetExecutableSigner(string filePath)
+    {
+        try
+        {
+            var cert = new X509Certificate2(X509Certificate.CreateFromSignedFile(filePath));
+            return cert.Subject;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+
+    /// <summary>
+    /// Determines whether the Ubisoft Plus environment is detected based on several criteria.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if the Ubisoft Plus environment is detected; otherwise, <c>false</c>.
+    /// </returns>
+    internal static bool UbisoftPlusDetected()
+    {
+        if (UbisoftPlus) return true;
+        var signer = GetExecutableSigner(ExecutablePath);
+        return signer != null &&
+               signer.StartsWith("cn=ubisoft", StringComparison.OrdinalIgnoreCase) &&
+               ProcessName.EndsWith("_plus", StringComparison.OrdinalIgnoreCase) &&
+               File.Exists(Path.Combine(GameRootPath, "GameAssembly_plus.dll"));
+    }
 
     public static void SetExecutablePath(string executablePath,
                                          string bepinRootPath = null,
@@ -100,12 +146,24 @@ public static class Paths
                                          string[] dllSearchPath = null)
     {
         ExecutablePath = executablePath;
+
         ProcessName = Path.GetFileNameWithoutExtension(executablePath);
 
         GameRootPath = PlatformHelper.Is(Platform.MacOS)
                            ? Utility.ParentDirectory(executablePath, 4)
                            : Path.GetDirectoryName(executablePath);
 
+        if (UbisoftPlusDetected())
+        {
+            UbisoftPlus = true;
+            ProcessName = ProcessName.Replace("_plus", string.Empty);
+        }
+        else
+        {
+            UbisoftPlus = false;
+        }
+
+        
         GameDataPath = managedPath != null && gameDataRelativeToManaged
                            ? Path.GetDirectoryName(managedPath)
                            : Path.Combine(GameRootPath, $"{ProcessName}_Data");

--- a/BepInEx.Preloader.Core/Logging/ChainloaderLogHelper.cs
+++ b/BepInEx.Preloader.Core/Logging/ChainloaderLogHelper.cs
@@ -38,6 +38,10 @@ public static class ChainloaderLogHelper
         var versionMini = new SemanticVersioning.Version(bepinVersion.Major, bepinVersion.Minor, bepinVersion.Patch,
                                                          bepinVersion.PreRelease);
         var consoleTitle = $"BepInEx {versionMini} - {Paths.ProcessName}";
+        if (Paths.UbisoftPlusDetected())
+        {
+            consoleTitle = $"BepInEx {versionMini} - {Paths.ProcessName} (Ubisoft+)";  
+        }
         log.Log(LogLevel.Message, consoleTitle);
 
         if (ConsoleManager.ConsoleActive)

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -95,9 +95,24 @@ internal static partial class Il2CppInteropManager
 
     private static bool initialized;
 
-    public static string GameAssemblyPath => Environment.GetEnvironmentVariable("BEPINEX_GAME_ASSEMBLY_PATH") ??
-                                             Path.Combine(Paths.GameRootPath,
-                                                          "GameAssembly." + PlatformHelper.LibrarySuffix);
+    public static string GameAssemblyPath
+    {
+        get
+        {
+            var s = Environment.GetEnvironmentVariable("BEPINEX_GAME_ASSEMBLY_PATH");
+            if (s != null)
+            {
+                return s;
+            }
+            if (Paths.UbisoftPlusDetected())
+            {
+                return Path.Combine(Paths.GameRootPath,
+                                    "GameAssembly_plus." + PlatformHelper.LibrarySuffix);
+            }
+            return Path.Combine(Paths.GameRootPath,
+                                "GameAssembly." + PlatformHelper.LibrarySuffix);
+        }
+    }
 
     private static string HashPath => Path.Combine(IL2CPPInteropAssemblyPath, "assembly-hash.txt");
 

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Preloader.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Preloader.cs
@@ -96,11 +96,6 @@ public static class Preloader
 
     private static IntPtr DllImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
     {
-        if (libraryName == "GameAssembly")
-        {
-            return NativeLibrary.Load(Il2CppInteropManager.GameAssemblyPath, assembly, searchPath);
-        }
-
-        return IntPtr.Zero;
+        return libraryName is "GameAssembly" or "GameAssembly_plus" ? NativeLibrary.Load(Il2CppInteropManager.GameAssemblyPath, assembly, searchPath) : IntPtr.Zero;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added exe signature checks, checking for Ubisoft, combined with checking for the presence of "_plus" in filenames, and the existence of a second GameAssembly file.
- Modifications to pathing based on the result above.
- There is also a corresponding [IL2CppInterop pull request.](https://github.com/BepInEx/Il2CppInterop/pull/114)

## Motivation and Context
Prince of Persia: The Lost Crown from Ubisoft uses Unity (IL2CPP). As they offer both retail and subscription versions, they have two executables and two game assembly files based on edition. Retail users were fine, but users using Ubisoft+ weren't as process names and game assembly filenames are hardcoded.

The change came about because members of the ultra-wide community requested a fix for the game, and here we discovered it doesn't work on Ubisoft+ due to reasons above.

## How Has This Been Tested?
- I own the retail copy of the game, and have a separate Ubisoft+ subscription, so tested personally.
- Members of the ultrawide community (WSGF etc.), who are a mix of retail and subscription have tested it successfully.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
