### PR TITLE
Add public GetInteropAssemblyPath

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Preloader.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Preloader.cs
@@ -21,6 +21,13 @@ public static class Preloader
     // TODO: This is not needed, maybe remove? (Instance is saved in IL2CPPChainloader itself)
     private static IL2CPPChainloader Chainloader { get; set; }
 
+    /// <summary>
+    ///     Path to a folder containing all of the IL2CPP interop assemblies for the current session.
+    ///     Interop assemblies are used to provide a bridge between managed plugins and C++ compiled game code.
+    ///     They are loaded automatically when referenced by managed code but not when passing objects between managed and unmanaged code.
+    /// </summary>
+    public static string GetInteropAssemblyPath() => Il2CppInteropManager.IL2CPPInteropAssemblyPath;
+
     public static void Run()
     {
         try


### PR DESCRIPTION
Currently there is no public member exposing the interop assembly path. I'm not sure what the best place to put it would be. Preloader seems appropriate, either that or IL2CPPChainloader.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
