### PR TITLE
Automatically load all interop assemblies before loading plugins

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/IL2CPPChainloader.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/IL2CPPChainloader.cs
@@ -93,6 +93,8 @@ public class IL2CPPChainloader : BaseChainloader<BasePlugin>
 
                 unhook = true;
 
+                Il2CppInteropManager.PreloadInteropAssemblies();
+
                 Instance.Execute();
             }
             catch (Exception ex)

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -384,8 +384,7 @@ internal static partial class Il2CppInteropManager
             if (file.EndsWith("netstandard.dll", StringComparison.OrdinalIgnoreCase)) return;
             try
             {
-                var assemblyName = AssemblyName.GetAssemblyName(file);
-                Assembly.Load(assemblyName);
+                Assembly.LoadFrom(file);
                 Interlocked.Increment(ref loaded);
             }
             catch (Exception e)

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -8,6 +8,8 @@ using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using BepInEx.Configuration;
 using BepInEx.Logging;
 using BepInEx.Unity.Common;
@@ -376,7 +378,7 @@ internal static partial class Il2CppInteropManager
 
         var files = Directory.EnumerateFiles(IL2CPPInteropAssemblyPath);
         var loaded = 0;
-        System.Threading.Tasks.Parallel.ForEach(files, file =>
+        Parallel.ForEach(files, file =>
         {
             if (!file.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)) return;
             if (file.EndsWith("netstandard.dll", StringComparison.OrdinalIgnoreCase)) return;
@@ -384,7 +386,7 @@ internal static partial class Il2CppInteropManager
             {
                 var assemblyName = AssemblyName.GetAssemblyName(file);
                 Assembly.Load(assemblyName);
-                System.Threading.Interlocked.Increment(ref loaded);
+                Interlocked.Increment(ref loaded);
             }
             catch (Exception e)
             {

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -381,7 +381,8 @@ internal static partial class Il2CppInteropManager
         Parallel.ForEach(files, file =>
         {
             if (!file.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)) return;
-            if (file.EndsWith("netstandard.dll", StringComparison.OrdinalIgnoreCase)) return;
+            if (file.Equals("netstandard.dll", StringComparison.OrdinalIgnoreCase)) return;
+            if (file.Equals("Il2Cppnetstandard.dll", StringComparison.OrdinalIgnoreCase)) return;
             try
             {
                 Assembly.LoadFrom(file);

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -388,10 +388,10 @@ internal static partial class Il2CppInteropManager
             }
             catch (Exception e)
             {
-                Logger.Log(BepInEx.Logging.LogLevel.Warning, $"Failed to preload {file} - {e}");
+                Logger.LogWarning($"Failed to preload {file} - {e}");
             }
         });
 
-        Logger.Log(BepInEx.Logging.LogLevel.Debug, $"Preloaded {loaded} interop assemblies in {sw.ElapsedMilliseconds}ms");
+        Logger.LogDebug($"Preloaded {loaded} interop assemblies in {sw.ElapsedMilliseconds}ms");
     }
 }


### PR DESCRIPTION
Assemblies are often loaded on the il2cpp side but not on the mono side, causing confusion when using reflection.
This will load all interop assemblies right before plugins are loaded, which should mostly avoid these issues at a low time cost of around 40ms.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
