### PR TITLE
Process GameAssembly.dll and global.metadata.dll from runtime

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/BepInEx.Unity.IL2CPP.csproj
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/BepInEx.Unity.IL2CPP.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>BepInEx support library for Il2Cpp games</Description>
         <TargetFramework>net6.0</TargetFramework>
@@ -15,14 +15,15 @@
     <ItemGroup>
         <PackageReference Include="HarmonyX" Version="2.10.1"/>
         <PackageReference Include="Iced" Version="1.18.0"/>
-        <PackageReference Include="Il2CppInterop.Generator" Version="1.4.6-ci.389"/>
-        <PackageReference Include="Il2CppInterop.HarmonySupport" Version="1.4.6-ci.389"/>
+        <PackageReference Include="Il2CppInterop.Generator" Version="1.4.6"/>
+        <PackageReference Include="Il2CppInterop.HarmonySupport" Version="1.4.6"/>
         <PackageReference Include="Il2CppInterop.ReferenceLibs" Version="1.0.0" IncludeAssets="compile" PrivateAssets="all"/>
-        <PackageReference Include="Il2CppInterop.Runtime" Version="1.4.6-ci.389"/>
+        <PackageReference Include="Il2CppInterop.Runtime" Version="1.4.6"/>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" IncludeAssets="compile" PrivateAssets="all"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" IncludeAssets="compile" PrivateAssets="all"/>
         <PackageReference Include="MonoMod.RuntimeDetour" Version="22.5.1.1"/>
         <PackageReference Include="Samboy063.Cpp2IL.Core" Version="2022.1.0-development.866"/>
+        <PackageReference Include="Il2CppDumper" Version="1.0.0" />
     </ItemGroup>
 
     <!-- CopyLocalLockFileAssemblies causes to also output shared assemblies: https://github.com/NuGet/Home/issues/4837#issuecomment-354536302 -->

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -87,6 +87,25 @@ internal static partial class Il2CppInteropManager
          .AppendLine("Supports the following placeholders:")
          .AppendLine("{BepInEx} - Path to the BepInEx folder.")
          .AppendLine("{ProcessName} - Name of the current process")
+         .AppendLine("{AppData} - Path to the user AppData folder")
+         .ToString());
+
+    private static readonly ConfigEntry<bool> UseRuntimeAssemblies = ConfigFile.CoreConfig.Bind(
+     "IL2CPP", "UseRuntimeAssemblies",
+     true,
+     new StringBuilder()
+         .AppendLine("If enabled, BepInEx will save runtime binaries from process memory into BepInEx/runtime-bins.")
+         .AppendLine("IL2CPPDumper will then use them to generate dummy assemblies for IL2CPPInterop.")
+         .AppendLine("Use this if GameAssembly.dll is packed or global-metadata.dat is embedded.")
+         .ToString());
+
+    private static readonly ConfigEntry<int> ObfuscatedMetadataHeaderOffset = ConfigFile.CoreConfig.Bind(
+     "IL2CPP", "ObfuscatedMetadataHeaderOffset",
+     8,
+     new StringBuilder()
+         .AppendLine("The offset of the standard metadata header to skip when searching embedded global-metadata.dat.")
+         .AppendLine("Use this if global-metadata.dat is embedded and beginning of the header is obfuscated.")
+         .AppendLine("IL2CPPInterop will search for global-metadata.dat using standard metadata header.")
          .ToString());
 
     private static readonly ManualLogSource Logger = BepInEx.Logging.Logger.CreateLogSource("InteropManager");
@@ -94,6 +113,8 @@ internal static partial class Il2CppInteropManager
     private static string il2cppInteropBasePath;
 
     private static bool initialized;
+
+    private static string ApplicationDataPath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "BepInEx", Paths.ProcessName);
 
     public static string GameAssemblyPath => Environment.GetEnvironmentVariable("BEPINEX_GAME_ASSEMBLY_PATH") ??
                                              Path.Combine(Paths.GameRootPath,
@@ -107,7 +128,8 @@ internal static partial class Il2CppInteropManager
                 return il2cppInteropBasePath;
             var path = Utility.GetCommandLineArgValue("--unhollowed-path") ?? IL2CPPInteropAssembliesPath.Value;
             il2cppInteropBasePath = path.Replace("{BepInEx}", Paths.BepInExRootPath)
-                                     .Replace("{ProcessName}", Paths.ProcessName);
+                                     .Replace("{ProcessName}", Paths.ProcessName)
+                                     .Replace("{AppData}", ApplicationDataPath);
             return il2cppInteropBasePath;
         }
     }
@@ -115,6 +137,8 @@ internal static partial class Il2CppInteropManager
     private static string UnityBaseLibsDirectory => Path.Combine(IL2CPPBasePath, "unity-libs");
 
     internal static string IL2CPPInteropAssemblyPath => Path.Combine(IL2CPPBasePath, "interop");
+
+    internal static string IL2CPPRuntimeBinariesPath => Path.Combine(IL2CPPBasePath, "runtime-bins");
 
     private static ILoggerFactory LoggerFactory { get; } = MSLoggerFactory.Create(b =>
     {

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -87,7 +87,7 @@ internal static partial class Il2CppInteropManager
          .AppendLine("Supports the following placeholders:")
          .AppendLine("{BepInEx} - Path to the BepInEx folder.")
          .AppendLine("{ProcessName} - Name of the current process")
-         .AppendLine("{AppData} - Path to the user AppData folder")
+         .AppendLine("{ApplicationData} - Path to the user AppData/Roaming folder")
          .ToString());
 
     private static readonly ConfigEntry<bool> UseRuntimeAssemblies = ConfigFile.CoreConfig.Bind(
@@ -99,13 +99,31 @@ internal static partial class Il2CppInteropManager
          .AppendLine("Use this if GameAssembly.dll is packed or global-metadata.dat is embedded.")
          .ToString());
 
+    private static readonly ConfigEntry<string> MetadataSignatureToScan = ConfigFile.CoreConfig.Bind(
+     "IL2CPP", "MetadataSignatureToScan",
+     "AC0E0000000000000000000001000000000000000400000001000000040000000500000006000000090000000D0000000F000000040000001C00000005000000200000000500000025000000070000002A0000000A00000031000000070000003B00000005000000420000000500000047000000050000004C0000000F0000005100000005000000600000000700000065000000090000006C0000000600000075000000030000007B0000000D0000007E000000030000008B0000001A0000008E00000001000000A800000004000000A90000000D000000AD00000005000000BA00000007000000BF0000000F000000C600000001000000D500000001000000",
+     new StringBuilder()
+         .AppendLine("The hex string of the metadata signature to scan when searching embedded global-metadata.dat.")
+         .AppendLine("Use this if global-metadata.dat is embedded and beginning of the header is obfuscated.")
+         .AppendLine("IL2CPPInterop will search for global-metadata.dat using this signature.")
+         .ToString());
+
     private static readonly ConfigEntry<int> ObfuscatedMetadataHeaderOffset = ConfigFile.CoreConfig.Bind(
      "IL2CPP", "ObfuscatedMetadataHeaderOffset",
-     8,
+     252,
      new StringBuilder()
          .AppendLine("The offset of the standard metadata header to skip when searching embedded global-metadata.dat.")
          .AppendLine("Use this if global-metadata.dat is embedded and beginning of the header is obfuscated.")
-         .AppendLine("IL2CPPInterop will search for global-metadata.dat using standard metadata header.")
+         .AppendLine("IL2CPPInterop will search for global-metadata.dat using this offset.")
+         .ToString());
+
+    private static readonly ConfigEntry<string> MagicToFix = ConfigFile.CoreConfig.Bind(
+     "IL2CPP", "MagicToFix",
+     string.Empty,
+     new StringBuilder()
+         .AppendLine("The magic bytes to fix the header of global-metadta.dat so il2cppdumper can use to determine version.")
+         .AppendLine("Use this if global-metadata.dat is embedded and beginning of the header is obfuscated.")
+         .AppendLine("IL2CPPInterop will fix global-metadata.dat using this magic.")
          .ToString());
 
     private static readonly ManualLogSource Logger = BepInEx.Logging.Logger.CreateLogSource("InteropManager");
@@ -122,14 +140,16 @@ internal static partial class Il2CppInteropManager
 
     private static string HashPath => Path.Combine(IL2CPPInteropAssemblyPath, "assembly-hash.txt");
 
-    private static string IL2CPPBasePath {
-        get {
+    private static string IL2CPPBasePath
+    {
+        get
+        {
             if (il2cppInteropBasePath != null)
                 return il2cppInteropBasePath;
             var path = Utility.GetCommandLineArgValue("--unhollowed-path") ?? IL2CPPInteropAssembliesPath.Value;
             il2cppInteropBasePath = path.Replace("{BepInEx}", Paths.BepInExRootPath)
                                      .Replace("{ProcessName}", Paths.ProcessName)
-                                     .Replace("{AppData}", ApplicationDataPath);
+                                     .Replace("{ApplicationData}", ApplicationDataPath);
             return il2cppInteropBasePath;
         }
     }
@@ -236,10 +256,10 @@ internal static partial class Il2CppInteropManager
 
         var unityVersion = UnityInfo.Version;
         Il2CppInteropRuntime.Create(new RuntimeConfiguration
-                            {
-                                UnityVersion = new Version(unityVersion.Major, unityVersion.Minor, unityVersion.Build),
-                                DetourProvider = new Il2CppInteropDetourProvider()
-                            })
+        {
+            UnityVersion = new Version(unityVersion.Major, unityVersion.Minor, unityVersion.Build),
+            DetourProvider = new Il2CppInteropDetourProvider()
+        })
                             .AddLogger(interopLogger)
                             .AddHarmonySupport()
                             .Start();
@@ -257,12 +277,11 @@ internal static partial class Il2CppInteropManager
 
             AppDomain.CurrentDomain.AddCecilPlatformAssemblies(UnityBaseLibsDirectory);
             DownloadUnityAssemblies();
-            var asmResolverAssemblies = RunCpp2Il();
-            var cecilAssemblies = new AsmToCecilConverter(asmResolverAssemblies).ConvertAll();
+            var cecilAssemblies = UseRuntimeAssemblies.Value ? RunIl2CppDumperWithRuntimeBinaries() : new AsmToCecilConverter(RunCpp2Il()).ConvertAll();
 
             if (DumpDummyAssemblies.Value)
             {
-                var dummyPath = Path.Combine(Paths.BepInExRootPath, "dummy");
+                var dummyPath = Path.Combine(IL2CPPBasePath, "dummy");
                 Directory.CreateDirectory(dummyPath);
                 foreach (var assemblyDefinition in cecilAssemblies)
                     assemblyDefinition.Write(Path.Combine(dummyPath, $"{assemblyDefinition.Name.Name}.dll"));
@@ -347,6 +366,59 @@ internal static partial class Il2CppInteropManager
 
         stopwatch.Stop();
         Logger.LogInfo($"Cpp2IL finished in {stopwatch.Elapsed}");
+
+        return assemblies;
+    }
+
+    private static List<AssemblyDefinition> RunIl2CppDumperWithRuntimeBinaries()
+    {
+        var metadataPath = Path.Combine(Paths.GameRootPath,
+                        $"{Paths.ProcessName}_Data",
+                        "il2cpp_data",
+                        "Metadata",
+                        "global-metadata.dat");
+
+        static void WriteBytesToFile(string filePath, byte[] bytes)
+        {
+            using var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write);
+            stream.Write(bytes, 0, bytes.Length);
+        }
+
+        static void WriteBinariesToFile(byte[] il2cppBytes, byte[] metadataBytes)
+        {
+            Directory.CreateDirectory(IL2CPPRuntimeBinariesPath);
+            Directory.GetFiles(IL2CPPRuntimeBinariesPath).Do(File.Delete);
+
+            WriteBytesToFile(Path.Combine(IL2CPPRuntimeBinariesPath, "GameAssembly.dll"), il2cppBytes);
+            WriteBytesToFile(Path.Combine(IL2CPPRuntimeBinariesPath, "global-metadata.dat"), metadataBytes);
+        }
+
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
+
+        Logger.LogMessage("Reading process memory to generate runtime binaries");
+
+        var logger = LoggerFactory.CreateLogger("Il2CppInteropGen");
+
+        Il2CppInterop.Runtime.MemoryUtils.RuntimeModuleDump(logger, out var il2cppBytes, out var metadataBytes, Convert.FromHexString(MetadataSignatureToScan.Value), Convert.FromHexString(MagicToFix.Value), ObfuscatedMetadataHeaderOffset.Value);
+
+        // we write to disk once so we can still inspect the byproduct if validation fails later on.
+        WriteBinariesToFile(il2cppBytes, metadataBytes);
+
+        Logger.LogMessage("Validating runtime binaries");
+
+        Il2CppInterop.Runtime.MemoryUtils.ValidateMetadata(logger, metadataPath, il2cppBytes, ref metadataBytes);
+
+        // this time the product will be final
+        WriteBinariesToFile(il2cppBytes, metadataBytes);
+
+        Logger.LogMessage("Running Il2CppDumper with runtime binaries to generate dummy assemblies");
+
+        Il2CppDumper.ExtensionMethods.Init(il2cppBytes, metadataBytes, out var metadata, out var il2Cpp);
+        Il2CppDumper.ExtensionMethods.GenerateCecilAssemblies(metadata, il2Cpp, out var assemblies);
+
+        stopwatch.Stop();
+        Logger.LogInfo($"Il2CppDumper finished in {stopwatch.Elapsed}");
 
         return assemblies;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is an enhancement on top of #611 as the previous pull request added submodules.
- Implemented `Il2CppDumper version 6.7.40` as nuget.
This was done locally using [js6pak](https://github.com/js6pak)/[dotnet-link](https://github.com/js6pak/dotnet-link)
Approval of this pull request will need to make https://github.com/krulci/Il2CppDumper/commit/7e418fe3957c5c3bdcdd4af679d42747a88c9a2e as nuget
- Runtime module dump is implemented in https://github.com/BepInEx/Il2CppInterop/pull/122
This feature can be enabled in config with `UseRuntimeAssemblies` option
- Added `ApplicationData` as an option for `IL2CPPInteropAssembliesPath` option

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- `Il2CppInterop.Runtime+RuntimeModuleDump` will retrieve `GameAssembly.dll` from current process handle after temporarily setting memory protection to `execute_read_write`. Memory protection will be restore to its original state after module memory is read.
- `Il2CppInterop.Runtime+RuntimeModuleDump` will fix all sections so it can be processed by `Il2CppDumper`.
- `Il2CppInterop.Runtime+RuntimeModuleDump` will also extract `global-metadata.dat` from current process handle.
This feature is for games with `global-metadata.dat` embedded in `GameAssembly.dll`.
- Uses `Il2CppDumper` to process `List<Mono.Cecil.AssemblyDefinition>` since `Cpp2IL` is incompetent with memory dumped file.
- `ApplicationData` was added to reduce the need of initialization toolchain rerun for environment where `BepInEx` is removed upon exit.
- `MetadataSignatureToScan` and `ObfuscatedMetadataHeaderOffset` are a config entry that is supplied to `Il2CppInterop.Runtime+RuntimeModuleDump` for pattern matching. Default value is a relative consistent value starts from offset 252 of multiple `global-metadata.dat` investigated.
- `MagicToFix` is a config entry that is supplied to `Il2CppInterop.Runtime+RuntimeModuleDump` when the first 8 bytes of `global-metadata.dat` is obfuscated to determine `global-metadata.dat`'s version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with PrincessConnectReDive (JP)
`Chainloader startup complete`
Tested with Umamusume (JP)
`Chainloader startup complete`

## Screenshots (if appropriate):
![image](https://github.com/BepInEx/BepInEx/assets/52474054/1b0cc3d3-e0ea-4762-80df-ae15cd6d48af)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
