### PR TITLE
Upgrade Doorstop to version 4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Unity plugin framework
 **[User and developer guides](https://bepinex.github.io/bepinex_docs/master/articles/index.html)**
 
 ## Used libraries
-- [NeighTools/UnityDoorstop](https://github.com/NeighTools/UnityDoorstop) - 4.1.0 ([0b6b23d](https://github.com/NeighTools/UnityDoorstop/commit/0b6b23da18789627d9b2764585544ac81e562170))
+- [NeighTools/UnityDoorstop](https://github.com/NeighTools/UnityDoorstop) - 4.2.0 ([0b6b23d](https://github.com/NeighTools/UnityDoorstop/commit/0b6b23da18789627d9b2764585544ac81e562170))
 - [BepInEx/HarmonyX](https://github.com/BepInEx/HarmonyX) - 2.7.0 ([2537257](https://github.com/BepInEx/HarmonyX/commit/253725768e59b0e1ea90105cdbcc4a0a477422c7))
 - [MonoMod/MonoMod](https://github.com/MonoMod/MonoMod) - v21.12.13.01 ([ede81f4](https://github.com/MonoMod/MonoMod/commit/ede81f48924d58abf05359409fad740fe2b0dfb5))
 - [jbevain/cecil](https://github.com/jbevain/cecil) - 0.10.4 ([98ec890](https://github.com/jbevain/cecil/commit/98ec890d44643ad88d573e97be0e120435eda732))

--- a/build.cake
+++ b/build.cake
@@ -4,7 +4,7 @@
 #addin nuget:?package=Cake.Json&version=6.0.1
 #addin nuget:?package=Newtonsoft.Json&version=13.0.1
 
-const string DOORSTOP_VER = "4.1.0";
+const string DOORSTOP_VER = "4.2.0";
 
 var target = Argument("target", "Build");
 var isBleedingEdge = Argument("bleeding_edge", false);

--- a/doorstop/doorstop_config.ini
+++ b/doorstop/doorstop_config.ini
@@ -23,6 +23,7 @@ ignore_disable_switch = false
 # (e.g. mscorlib is stripped in original game)
 # This option causes Mono to seek mscorlib and core libraries from a different folder before Managed
 # Original Managed folder is added as a secondary folder in the search path
+# To specify multiple paths, separate them with semicolons (;)
 dll_search_path_override =
 
 # If true, Mono debugger server will be enabled

--- a/doorstop/run_bepinex.sh
+++ b/doorstop/run_bepinex.sh
@@ -36,6 +36,7 @@ ignore_disable_switch="0"
 # (e.g. mscorlib is stripped in original game)
 # This option causes Mono to seek mscorlib and core libraries from a different folder before Managed
 # Original Managed folder is added as a secondary folder in the search path
+# To specify multiple paths, separate them with colons (:)
 dll_search_path_override=""
 
 # If 1, Mono debugger server will be enabled


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This upgrades Doorstop to version 4.2.0 which notably fixes a regression that was found with the 5.4.23 released version of bepinex where it couldn't hook its own assembly loading which prevented to shim Bepinex.Harmony when needed by legacy plugins.

## Motivation and Context
It fixes the regression found with the 5.4.23 release

## How Has This Been Tested?
I already tested doorstop on both windows and linux and confirmed the build system correctly downloaded a version that fixed the regression.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
