### PR TITLE
Upgrade doorstop to version 4.2.0 (v6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A more comprehensive comparison list of features and compatibility is available 
 
 ## Used libraries
 
-- [NeighTools/UnityDoorstop](https://github.com/NeighTools/UnityDoorstop) - v4.0.0
+- [NeighTools/UnityDoorstop](https://github.com/NeighTools/UnityDoorstop) - v4.2.0
 - [BepInEx/HarmonyX](https://github.com/BepInEx/HarmonyX) - v2.10.1
 - [0x0ade/MonoMod](https://github.com/0x0ade/MonoMod) - v22.5.1.1
 - [jbevain/cecil](https://github.com/jbevain/cecil) - v0.10.4

--- a/Runtimes/Unity/Doorstop/doorstop_config_mono.ini
+++ b/Runtimes/Unity/Doorstop/doorstop_config_mono.ini
@@ -23,7 +23,8 @@ ignore_disable_switch = false
 # (e.g. mscorlib is stripped in original game)
 # This option causes Mono to seek mscorlib and core libraries from a different folder before Managed
 # Original Managed folder is added as a secondary folder in the search path
-dll_search_path_override =
+# To specify multiple paths, separate them with semicolons (;)
+dll_search_path_override = "BepInEx\core"
 
 # If true, Mono debugger server will be enabled
 debug_enabled = false

--- a/Runtimes/Unity/Doorstop/run_bepinex_mono.sh
+++ b/Runtimes/Unity/Doorstop/run_bepinex_mono.sh
@@ -36,7 +36,8 @@ ignore_disable_switch="0"
 # (e.g. mscorlib is stripped in original game)
 # This option causes Mono to seek mscorlib and core libraries from a different folder before Managed
 # Original Managed folder is added as a secondary folder in the search path
-dll_search_path_override=""
+# To specify multiple paths, separate them with colons (:)
+dll_search_path_override="BepInEx/core"
 
 # If 1, Mono debugger server will be enabled
 debug_enable="0"

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -32,7 +32,7 @@ public class BuildContext : FrostingContext
         BleedingEdge
     }
 
-    public const string DoorstopVersion = "4.0.0";
+    public const string DoorstopVersion = "4.2.0";
     public const string DotnetRuntimeVersion = "6.0.7";
     public const string DobbyVersion = "1.0.5";
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This upgrades bepinex (master) to use Doorstop version 4.2.0 with equivalent defaults regarding the mono search paths changes

## Motivation and Context
It fixes minor issues and improves the flexibility regarding the mono search path.

## How Has This Been Tested?
I haven't tested much besides the fact that it compiles (I am not familiar with v6 enough)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
