### PR TITLE
Downgrade AssetRipper.Primitives patch to avoid implying Json 8.0.1

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.Common/BepInEx.Unity.Common.csproj
+++ b/Runtimes/Unity/BepInEx.Unity.Common/BepInEx.Unity.Common.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AssetRipper.Primitives" Version="2.1.1"/>
+        <PackageReference Include="AssetRipper.Primitives" Version="2.1.0"/>
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all"/>
         <PackageReference Include="MonoMod.Utils" Version="22.5.1.1"/>
     </ItemGroup>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Downgrading AssetRipper.Primitives from 2.1.1 to 2.1.0 to avoid implying System.Text.Json 8.0.1 during build using current BE feed.

## Motivation and Context
This [recent change](https://github.com/BepInEx/BepInEx/pull/869/files#diff-1808545a857570552cec80a9267f5d9587e61a46ec9049026e13062d053e62e3 ) to support V Rising included `AssetRipper.Primitives 2.1.1` [that change implies](https://github.com/AssetRipper/AssetRipper.Primitives/commit/bd575f00637492f91334101548a8aa4edc406fdc#diff-e591a497e52e87166138cece28b23cd1a175f4e818ba6efa901995c1f31659d5) `System.Net.Json 8.0.1` . This causes a NU1605 build warning as error when referencing BE690 nugets. We know that .net 6 is available at runtime, so it is possible to ignore the warning. This change removes the need to ignore that warning.

## How Has This Been Tested?
I built BepInEx locally, used it for V Rising server and referenced in two plugins: I built a test plugin and updated a large existing plugin. They built without the warning and functioned in game. To test end to end I built a small test command that echos JSON.

## Screenshots (if appropriate):
![image](https://github.com/BepInEx/BepInEx/assets/62450933/24df416f-b9c9-4337-a245-eda7407dc31b)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
