### PR TITLE
Upgrade Doorstop to version 4.3.0 (v5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Unity plugin framework
 **[User and developer guides](https://bepinex.github.io/bepinex_docs/master/articles/index.html)**
 
 ## Used libraries
-- [NeighTools/UnityDoorstop](https://github.com/NeighTools/UnityDoorstop) - 4.2.0 ([0b6b23d](https://github.com/NeighTools/UnityDoorstop/commit/0b6b23da18789627d9b2764585544ac81e562170))
+- [NeighTools/UnityDoorstop](https://github.com/NeighTools/UnityDoorstop) - 4.3.0 ([d061d7e](https://github.com/NeighTools/UnityDoorstop/commit/d061d7eabe9fc36140e7239955515801e2b9db12))
 - [BepInEx/HarmonyX](https://github.com/BepInEx/HarmonyX) - 2.7.0 ([2537257](https://github.com/BepInEx/HarmonyX/commit/253725768e59b0e1ea90105cdbcc4a0a477422c7))
 - [MonoMod/MonoMod](https://github.com/MonoMod/MonoMod) - v21.12.13.01 ([ede81f4](https://github.com/MonoMod/MonoMod/commit/ede81f48924d58abf05359409fad740fe2b0dfb5))
 - [jbevain/cecil](https://github.com/jbevain/cecil) - 0.10.4 ([98ec890](https://github.com/jbevain/cecil/commit/98ec890d44643ad88d573e97be0e120435eda732))

--- a/build.cake
+++ b/build.cake
@@ -4,7 +4,7 @@
 #addin nuget:?package=Cake.Json&version=6.0.1
 #addin nuget:?package=Newtonsoft.Json&version=13.0.1
 
-const string DOORSTOP_VER = "4.2.0";
+const string DOORSTOP_VER = "4.3.0";
 
 var target = Argument("target", "Build");
 var isBleedingEdge = Argument("bleeding_edge", false);

--- a/doorstop/doorstop_config.ini
+++ b/doorstop/doorstop_config.ini
@@ -11,6 +11,9 @@ target_assembly=BepInEx\core\BepInEx.Preloader.dll
 # If true, Unity's output log is redirected to <current folder>\output_log.txt
 redirect_output_log = false
 
+# Overrides the default boot.config file path
+boot_config_override =
+
 # If enabled, DOORSTOP_DISABLE env var value is ignored
 # USE THIS ONLY WHEN ASKED TO OR YOU KNOW WHAT THIS MEANS
 ignore_disable_switch = false

--- a/doorstop/run_bepinex.sh
+++ b/doorstop/run_bepinex.sh
@@ -25,6 +25,9 @@ enabled="1"
 # NOTE: The entrypoint must be of format `static void Doorstop.Entrypoint.Start()`
 target_assembly="BepInEx/core/BepInEx.Preloader.dll"
 
+# Overrides the default boot.config file path
+boot_config_override=
+
 # If enabled, DOORSTOP_DISABLE env var value is ignored
 # USE THIS ONLY WHEN ASKED TO OR YOU KNOW WHAT THIS MEANS
 ignore_disable_switch="0"
@@ -205,6 +208,10 @@ while :; do
         ;;
         --doorstop_target_assembly)
             target_assembly="$2"
+            shift
+        ;;
+        --doorstop-boot-config-override)
+            boot_config_override="$2"
             shift
         ;;
         --doorstop-mono-dll-search-path-override)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Upgrade Doorstop to version 4.3.0. This fixes a regression where dnspy debugging broke on old mono. By the same token, it adds 2 features:
- It is now possible to redirect the untiy's boot.config file
- Doorstop debugging now works on old mono and dnspy debugging no longer requires a patched mono even if it is an old mono.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It fixes a regression where dnspy debugging broke on old mono and adds 2 interesting features that the new version of doorstop offers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested that the build system correctly obtained the new doorstop on all builds and tested in a unity 2018.4.12 game with 2 versions (one that released with old mono and another that released with new mono).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
