### PR TITLE
Upgrade Doorstop to 4.3.0 (v6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A more comprehensive comparison list of features and compatibility is available 
 
 ## Used libraries
 
-- [NeighTools/UnityDoorstop](https://github.com/NeighTools/UnityDoorstop) - v4.2.0
+- [NeighTools/UnityDoorstop](https://github.com/NeighTools/UnityDoorstop) - v4.3.0
 - [BepInEx/HarmonyX](https://github.com/BepInEx/HarmonyX) - v2.10.1
 - [0x0ade/MonoMod](https://github.com/0x0ade/MonoMod) - v22.5.1.1
 - [jbevain/cecil](https://github.com/jbevain/cecil) - v0.10.4

--- a/Runtimes/Unity/Doorstop/doorstop_config_il2cpp.ini
+++ b/Runtimes/Unity/Doorstop/doorstop_config_il2cpp.ini
@@ -11,6 +11,9 @@ target_assembly = BepInEx\core\BepInEx.Unity.IL2CPP.dll
 # If true, Unity's output log is redirected to <current folder>\output_log.txt
 redirect_output_log = false
 
+# Overrides the default boot.config file path
+boot_config_override =
+
 # If enabled, DOORSTOP_DISABLE env var value is ignored
 # USE THIS ONLY WHEN ASKED TO OR YOU KNOW WHAT THIS MEANS
 ignore_disable_switch = false

--- a/Runtimes/Unity/Doorstop/doorstop_config_mono.ini
+++ b/Runtimes/Unity/Doorstop/doorstop_config_mono.ini
@@ -11,6 +11,9 @@ target_assembly = BepInEx\core\BepInEx.Unity.Mono.Preloader.dll
 # If true, Unity's output log is redirected to <current folder>\output_log.txt
 redirect_output_log = false
 
+# Overrides the default boot.config file path
+boot_config_override =
+
 # If enabled, DOORSTOP_DISABLE env var value is ignored
 # USE THIS ONLY WHEN ASKED TO OR YOU KNOW WHAT THIS MEANS
 ignore_disable_switch = false

--- a/Runtimes/Unity/Doorstop/run_bepinex_il2cpp.sh
+++ b/Runtimes/Unity/Doorstop/run_bepinex_il2cpp.sh
@@ -25,6 +25,9 @@ enabled="1"
 # NOTE: The entrypoint must be of format `static void Doorstop.Entrypoint.Start()`
 target_assembly="BepInEx/core/BepInEx.Unity.IL2CPP.dll"
 
+# Overrides the default boot.config file path
+boot_config_override=
+
 # If enabled, DOORSTOP_DISABLE env var value is ignored
 # USE THIS ONLY WHEN ASKED TO OR YOU KNOW WHAT THIS MEANS
 ignore_disable_switch="0"
@@ -216,6 +219,10 @@ while :; do
         ;;
         --doorstop_target_assembly)
             target_assembly="$2"
+            shift
+        ;;
+        --doorstop-boot-config-override)
+            boot_config_override="$2"
             shift
         ;;
         --doorstop-mono-dll-search-path-override)

--- a/Runtimes/Unity/Doorstop/run_bepinex_mono.sh
+++ b/Runtimes/Unity/Doorstop/run_bepinex_mono.sh
@@ -25,6 +25,9 @@ enabled="1"
 # NOTE: The entrypoint must be of format `static void Doorstop.Entrypoint.Start()`
 target_assembly="BepInEx/core/BepInEx.Unity.Mono.Preloader.dll"
 
+# Overrides the default boot.config file path
+boot_config_override=
+
 # If enabled, DOORSTOP_DISABLE env var value is ignored
 # USE THIS ONLY WHEN ASKED TO OR YOU KNOW WHAT THIS MEANS
 ignore_disable_switch="0"
@@ -217,6 +220,10 @@ while :; do
         ;;
         --doorstop_target_assembly)
             target_assembly="$2"
+            shift
+        ;;
+        --doorstop-boot-config-override)
+            boot_config_override="$2"
             shift
         ;;
         --doorstop-mono-dll-search-path-override)

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -32,7 +32,7 @@ public class BuildContext : FrostingContext
         BleedingEdge
     }
 
-    public const string DoorstopVersion = "4.2.0";
+    public const string DoorstopVersion = "4.3.0";
     public const string DotnetRuntimeVersion = "6.0.7";
     public const string DobbyVersion = "1.0.5";
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Upgrade Doorstop to version 4.3.0. This fixes a regression from v5 where dnspy debugging broke on old mono. By the same token, it adds 2 features:
- It is now possible to redirect the untiy's boot.config file
- Doorstop debugging now works on old mono and dnspy debugging no longer requires a patched mono even if it is an old mono.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It fixes a regression from v5 where dnspy debugging broke on old mono and adds 2 interesting features that the new version of doorstop offers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested that the build system correctly obtained the new doorstop on all builds and tested in a unity 2018.4.12 game with 2 versions (one that released with old mono and another that released with new mono).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
