### PR TITLE
Bump Cpp2IL

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/BepInEx.Unity.IL2CPP.csproj
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/BepInEx.Unity.IL2CPP.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" IncludeAssets="compile" PrivateAssets="all"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" IncludeAssets="compile" PrivateAssets="all"/>
         <PackageReference Include="MonoMod.RuntimeDetour" Version="22.5.1.1"/>
-        <PackageReference Include="Samboy063.Cpp2IL.Core" Version="2022.1.0-development.972"/>
+        <PackageReference Include="Samboy063.Cpp2IL.Core" Version="2022.1.0-development.1057"/>
     </ItemGroup>
 
     <!-- CopyLocalLockFileAssemblies causes to also output shared assemblies: https://github.com/NuGet/Home/issues/4837#issuecomment-354536302 -->

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/BepInEx.Unity.IL2CPP.csproj
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/BepInEx.Unity.IL2CPP.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" IncludeAssets="compile" PrivateAssets="all"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" IncludeAssets="compile" PrivateAssets="all"/>
         <PackageReference Include="MonoMod.RuntimeDetour" Version="22.5.1.1"/>
-        <PackageReference Include="Samboy063.Cpp2IL.Core" Version="2022.1.0-development.1057"/>
+        <PackageReference Include="Samboy063.Cpp2IL.Core" Version="2022.1.0-pre-release.18"/>
     </ItemGroup>
 
     <!-- CopyLocalLockFileAssemblies causes to also output shared assemblies: https://github.com/NuGet/Home/issues/4837#issuecomment-354536302 -->


### PR DESCRIPTION
Bumps Cpp2IL to the latest prerelease (18). ~~It isn't on nuget, so the new package reference points to the corresponding CI build on [nuget.samboy.dev](nuget.samboy.dev).~~

## Motivation and Context
The currently used version doesn't have support for metadata version 29.2 (Unity 2023.2+) and 31 (2022.3.33+). From the discord server: https://discord.com/channels/623153565053222947/754333645199900723/1277435800153358457

## How Has This Been Tested?
~~It hasn't, which is why this PR is currently a draft.~~
