### PR TITLE
Upgrade MonoMod to 22.7.31.1 to fix old mono preloader crashes

### DIFF
--- a/BepInEx.Core/BepInEx.Core.csproj
+++ b/BepInEx.Core/BepInEx.Core.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All"/>
         <PackageReference Include="HarmonyX" Version="2.10.2" />
         <PackageReference Include="SemanticVersioning" Version="2.0.2"/>
-        <PackageReference Include="MonoMod.Utils" Version="22.5.1.1"/>
+        <PackageReference Include="MonoMod.Utils" Version="22.7.31.1"/>
     </ItemGroup>
     <ItemGroup>
         <Compile Remove="Contract\IPlugin.cs"/>

--- a/BepInEx.Preloader.Core/BepInEx.Preloader.Core.csproj
+++ b/BepInEx.Preloader.Core/BepInEx.Preloader.Core.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All"/>
         <PackageReference Include="HarmonyX" Version="2.10.2" />
-        <PackageReference Include="MonoMod.RuntimeDetour" Version="22.5.1.1"/>
-        <PackageReference Include="MonoMod.Utils" Version="22.5.1.1"/>
+        <PackageReference Include="MonoMod.RuntimeDetour" Version="22.7.31.1"/>
+        <PackageReference Include="MonoMod.Utils" Version="22.7.31.1"/>
     </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A more comprehensive comparison list of features and compatibility is available 
 
 - [NeighTools/UnityDoorstop](https://github.com/NeighTools/UnityDoorstop) - v4.3.0
 - [BepInEx/HarmonyX](https://github.com/BepInEx/HarmonyX) - v2.10.2
-- [0x0ade/MonoMod](https://github.com/0x0ade/MonoMod) - v22.5.1.1
+- [0x0ade/MonoMod](https://github.com/0x0ade/MonoMod) - v22.7.31.1
 - [jbevain/cecil](https://github.com/jbevain/cecil) - v0.10.4
 
 #### IL2CPP libraries

--- a/Runtimes/Unity/BepInEx.Unity.Common/BepInEx.Unity.Common.csproj
+++ b/Runtimes/Unity/BepInEx.Unity.Common/BepInEx.Unity.Common.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="AssetRipper.Primitives" Version="3.1.3" />
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all"/>
-        <PackageReference Include="MonoMod.Utils" Version="22.5.1.1"/>
+        <PackageReference Include="MonoMod.Utils" Version="22.7.31.1"/>
     </ItemGroup>
 
 </Project>

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/BepInEx.Unity.IL2CPP.csproj
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/BepInEx.Unity.IL2CPP.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="Il2CppInterop.Runtime" Version="1.4.6-ci.426"/>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" IncludeAssets="compile" PrivateAssets="all"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" IncludeAssets="compile" PrivateAssets="all"/>
-        <PackageReference Include="MonoMod.RuntimeDetour" Version="22.5.1.1"/>
+        <PackageReference Include="MonoMod.RuntimeDetour" Version="22.7.31.1"/>
         <PackageReference Include="Samboy063.Cpp2IL.Core" Version="2022.1.0-development.972"/>
     </ItemGroup>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This simply upgrades the MonoMod version to the latest legacy one available which is non breaking, but allows to get a very important bugfix that has been preventing to boot old mono unity games (unity 5.x, 2017.x by default and optionally available in 2018.1-2019.1).

Currently, attempting to boot would yield this issue that has been documented before: https://github.com/MonoMod/MonoMod.Common/pull/23 . Essentially, a preloader crash happens due to an NRE in MonoMod's ReflectionHelper's cctor. It appears the issue was found and actually merged which was a simple fix by adding a `?` null check.

After investigation, the ONLY version of MonoMod legacy that includes this fix is 22.7.31.1 which is the last release of the legacy branch. This pr allows old mono games to boot due to this upgrade. It is a 3 versions upgrades, but a check of the changelogs reveals it only includes maintenance changes, nothing breaking unlike reorg MonoMod.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To allow old mono unity games to boot. While it might be better long term to upgrade to reorg MonoMod, it offers no ARM support currently so this upgrade can't be done yet. This pr then acts as a stopgap: it allows old mono games to work for now which helps for testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested by checking that UE loads on a unity 2018.4.12 game with 2 versions: one with old mono and the other with new mono. Both got past the preloader and loaded UE successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
