### PR TITLE
global-metadata.dat file location fallback

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -287,6 +287,19 @@ internal static partial class Il2CppInteropManager
                                         "Metadata",
                                         "global-metadata.dat");
 
+        if (!File.Exists(metadataPath))
+        {
+            var metadataPaths = Directory.GetFiles(Paths.GameRootPath, "global-metadata.dat", SearchOption.AllDirectories);
+
+            if (metadataPaths.Length > 1)
+                throw new AmbiguousMatchException($"Multiple global-metadata.dat files found at \n{string.Join("\n",metadataPaths)}");
+
+            if (metadataPaths.Length == 0)
+                throw new FileNotFoundException("Could not find global-metadata.dat anywhere in recursive search!");
+
+            metadataPath = metadataPaths[0];
+        }
+
         var stopwatch = new Stopwatch();
         stopwatch.Start();
 


### PR DESCRIPTION
## Description
Quick fix for games that do not append program name to the Data folder..

## Motivation and Context
Games sometimes don't put the program name appended before _data in the file path.  I found it in [Voxtopolis](https://voxtopolis.com/)

## How Has This Been Tested?
I ran his game ... before change no work, after change works fine...

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [?] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
