### PR TITLE
Fix failing to initialize if game's Data folder is just 'Data'

### DIFF
--- a/BepInEx.Core/Paths.cs
+++ b/BepInEx.Core/Paths.cs
@@ -112,6 +112,9 @@ public static class Paths
         }
         else
         {
+            // According to some experiments, Unity checks whether globalgamemanagers/data.unity3d exists in the data folder before picking it.
+            // 'ProcessName_Data' folder is checked first, then if that fails 'Data' folder is checked. If neither is valid, the player crashes.
+            // A simple Directory.Exists check is accurate enough while being less likely to break in case these conditions change.
             GameDataPath = Path.Combine(GameRootPath, $"{ProcessName}_Data");
             if (!Directory.Exists(GameDataPath))
                 GameDataPath = Path.Combine(GameRootPath, "Data");

--- a/BepInEx.Core/Paths.cs
+++ b/BepInEx.Core/Paths.cs
@@ -104,8 +104,7 @@ public static class Paths
 
         GameRootPath = PlatformHelper.Is(Platform.MacOS)
                            ? Utility.ParentDirectory(executablePath, 4)
-                           : Path.GetDirectoryName(executablePath) 
-                          ?? throw new DirectoryNotFoundException("Failed to extract GameRootPath from executablePath: " + executablePath);
+                           : Path.GetDirectoryName(executablePath);
 
         if (managedPath != null && gameDataRelativeToManaged)
         {
@@ -128,7 +127,8 @@ public static class Paths
         PluginPath = Path.Combine(BepInExRootPath, "plugins");
         PatcherPluginPath = Path.Combine(BepInExRootPath, "patchers");
         BepInExAssemblyDirectory = Path.Combine(BepInExRootPath, "core");
-        BepInExAssemblyPath = Path.Combine(BepInExAssemblyDirectory, $"{Assembly.GetExecutingAssembly().GetName().Name}.dll");
+        BepInExAssemblyPath = Path.Combine(BepInExAssemblyDirectory,
+                                           $"{Assembly.GetExecutingAssembly().GetName().Name}.dll");
         CachePath = Path.Combine(BepInExRootPath, "cache");
         DllSearchPaths = (dllSearchPath ?? new string[0]).Concat(new[] { ManagedPath }).Distinct().ToArray();
     }

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -281,8 +281,7 @@ internal static partial class Il2CppInteropManager
     {
         Logger.LogMessage("Running Cpp2IL to generate dummy assemblies");
 
-        var metadataPath = Path.Combine(Paths.GameRootPath,
-                                        $"{Paths.ProcessName}_Data",
+        var metadataPath = Path.Combine(Paths.GameDataPath,
                                         "il2cpp_data",
                                         "Metadata",
                                         "global-metadata.dat");


### PR DESCRIPTION
Any Unity game can have its _Data folder renamed to just `Data` and continue working just fine. The issue is BepInEx assumes that there is always a game name prefix, which causes a startup crash.

Closes #974

## How Has This Been Tested?
Tested locally on a game with a bunch of plugins already installed. Renamed data folder to `Data` and tried to regenerate interop assemblies, which crashed on master but worked fine on this PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
