### PR TITLE
Add GlobalMetadataPath setting

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -89,6 +89,15 @@ internal static partial class Il2CppInteropManager
          .AppendLine("{ProcessName} - Name of the current process")
          .ToString());
 
+    private static readonly ConfigEntry<string> GlobalMetadataRelativePath = ConfigFile.CoreConfig.Bind(
+     "IL2CPP", "GlobalMetadataRelativePath",
+     "{ProcessName}_Data/il2cpp_data/Metadata/global-metadata.dat",
+     new StringBuilder()
+         .AppendLine("The path to the IL2CPP metadata file, relative to the game root directory.")
+         .AppendLine("Supports the following placeholders:")
+         .AppendLine("{ProcessName} - Name of the current process")
+         .ToString());
+
     private static readonly ManualLogSource Logger = BepInEx.Logging.Logger.CreateLogSource("InteropManager");
 
     private static string il2cppInteropBasePath;
@@ -212,10 +221,10 @@ internal static partial class Il2CppInteropManager
 
         var unityVersion = UnityInfo.Version;
         Il2CppInteropRuntime.Create(new RuntimeConfiguration
-                            {
-                                UnityVersion = new Version(unityVersion.Major, unityVersion.Minor, unityVersion.Build),
-                                DetourProvider = new Il2CppInteropDetourProvider()
-                            })
+        {
+            UnityVersion = new Version(unityVersion.Major, unityVersion.Minor, unityVersion.Build),
+            DetourProvider = new Il2CppInteropDetourProvider()
+        })
                             .AddLogger(interopLogger)
                             .AddHarmonySupport()
                             .Start();
@@ -279,13 +288,10 @@ internal static partial class Il2CppInteropManager
 
     private static List<AsmResolver.DotNet.AssemblyDefinition> RunCpp2Il()
     {
-        Logger.LogMessage("Running Cpp2IL to generate dummy assemblies");
-
         var metadataPath = Path.Combine(Paths.GameRootPath,
-                                        $"{Paths.ProcessName}_Data",
-                                        "il2cpp_data",
-                                        "Metadata",
-                                        "global-metadata.dat");
+                                        GlobalMetadataRelativePath.Value.Replace("{ProcessName}", Paths.ProcessName));
+        
+        Logger.LogMessage("Running Cpp2IL to generate dummy assemblies from " + metadataPath);
 
         var stopwatch = new Stopwatch();
         stopwatch.Start();

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -223,10 +223,10 @@ internal static partial class Il2CppInteropManager
 
         var unityVersion = UnityInfo.Version;
         Il2CppInteropRuntime.Create(new RuntimeConfiguration
-        {
-            UnityVersion = new Version(unityVersion.Major, unityVersion.Minor, unityVersion.Build),
-            DetourProvider = new Il2CppInteropDetourProvider()
-        })
+                            {
+                                UnityVersion = new Version(unityVersion.Major, unityVersion.Minor, unityVersion.Build),
+                                DetourProvider = new Il2CppInteropDetourProvider()
+                            })
                             .AddLogger(interopLogger)
                             .AddHarmonySupport()
                             .Start();


### PR DESCRIPTION
## Description
Instead of hardcoding the metadata path expose it in config.

## Motivation and Context
Turns out this is super convenient to have when having to mess with metadata files. Don't have to edit bepinex for every change and it's possible to relocate decoded files into the bepinex directory to keep it self-contained.

## How Has This Been Tested?
Tested for regressions by updating existing installs and in new installs with relocated metadata.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
