### PR TITLE
Prioritize the shallowest path for the same assembly name in the default providers

### DIFF
--- a/BepInEx.PatcherProvider/BepInExPatcherProvider.cs
+++ b/BepInEx.PatcherProvider/BepInExPatcherProvider.cs
@@ -28,8 +28,13 @@ internal class BepInExPatcherProvider : BasePatcherProvider
                 {
                     int levelExistingDirectory = existingDirectory?.Count(x => x == Path.DirectorySeparatorChar) ?? 0;
                     int levelFoundDirectory = foundDirectory?.Count(x => x == Path.DirectorySeparatorChar) ?? 0;
-
-                    if (levelExistingDirectory > levelFoundDirectory) 
+                    
+                    bool shallowerPathFound = levelExistingDirectory > levelFoundDirectory;
+                    Log.LogWarning($"Found duplicate assemblies filenames: {filename} was found at {foundDirectory} " +
+                                   $"while it exists already at {AssemblyLocationsByFilename[filename]}. " +
+                                   $"Only the {(shallowerPathFound ? "first" : "second")} will be examined and resolved");
+                    
+                    if (levelExistingDirectory > levelFoundDirectory)
                         AssemblyLocationsByFilename[filename] = foundDirectory;
                 }
                 else

--- a/BepInEx.PatcherProvider/BepInExPatcherProvider.cs
+++ b/BepInEx.PatcherProvider/BepInExPatcherProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using BepInEx.Logging;
 using BepInEx.Preloader.Core.Patching;
@@ -19,7 +20,23 @@ internal class BepInExPatcherProvider : BasePatcherProvider
         {
             try
             {
-                AssemblyLocationsByFilename.Add(Path.GetFileNameWithoutExtension(dll), Path.GetDirectoryName(dll));
+                var filename = Path.GetFileNameWithoutExtension(dll);
+                var foundDirectory = Path.GetDirectoryName(dll);
+                
+                // Prioritize the shallowest path of each assembly name
+                if (AssemblyLocationsByFilename.TryGetValue(filename, out var existingDirectory))
+                {
+                    int levelExistingDirectory = existingDirectory?.Count(x => x == Path.DirectorySeparatorChar) ?? 0;
+                    int levelFoundDirectory = foundDirectory?.Count(x => x == Path.DirectorySeparatorChar) ?? 0;
+
+                    if (levelExistingDirectory > levelFoundDirectory) 
+                        AssemblyLocationsByFilename[filename] = foundDirectory;
+                }
+                else
+                {
+                    AssemblyLocationsByFilename.Add(filename, foundDirectory);
+                }
+                
                 loadContexts.Add(new BepInExPatcherLoadContext
                 {
                     AssemblyHash = File.GetLastWriteTimeUtc(dll).ToString("O"),

--- a/BepInEx.PluginProvider/BepInExPluginProvider.cs
+++ b/BepInEx.PluginProvider/BepInExPluginProvider.cs
@@ -28,7 +28,12 @@ internal class BepInExPluginProvider : BasePluginProvider
                     int levelExistingDirectory = existingDirectory?.Count(x => x == Path.DirectorySeparatorChar) ?? 0;
                     int levelFoundDirectory = foundDirectory?.Count(x => x == Path.DirectorySeparatorChar) ?? 0;
 
-                    if (levelExistingDirectory > levelFoundDirectory) 
+                    bool shallowerPathFound = levelExistingDirectory > levelFoundDirectory;
+                    Logger.LogWarning($"Found duplicate assemblies filenames: {filename} was found at {foundDirectory} " +
+                                      $"while it exists already at {AssemblyLocationsByFilename[filename]}. " +
+                                      $"Only the {(shallowerPathFound ? "first" : "second")} will be examined and resolved");
+                    
+                    if (levelExistingDirectory > levelFoundDirectory)
                         AssemblyLocationsByFilename[filename] = foundDirectory;
                 }
                 else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change the behaviors of the default providers so if multiple assemblies with the same name exists, but in different directories, ignore any that are located deeper.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes a problem where duplicate keys gets added to the dictionary because the file name without extensions is the same. In this situation, the path that is the shallowest should win over the deeper ones. This resolves this ambiguity.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested by placing the same assembly file names in the plugins directory, but one of them was 2 directories deeper. Testing shows it correctly picks the one at the root of the plugin folder instead of the one under the 2 directories.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
