### PR TITLE
v6: Workaround the Assembly.Location being empty on v6

### DIFF
--- a/BepInEx.PatcherProvider/BepInExPatcherProvider.cs
+++ b/BepInEx.PatcherProvider/BepInExPatcherProvider.cs
@@ -88,7 +88,7 @@ internal class BepInExPatcherProvider : BasePatcherProvider
                 return;
 
             var filenameWithoutExtension = Path.Combine(location, name);
-            __result = Path.ChangeExtension(filenameWithoutExtension, ".dll");
+            __result = filenameWithoutExtension + ".dll";
         }
     }
 }

--- a/BepInEx.PatcherProvider/BepInExPatcherProvider.cs
+++ b/BepInEx.PatcherProvider/BepInExPatcherProvider.cs
@@ -18,7 +18,7 @@ internal class BepInExPatcherProvider : BasePatcherProvider
     public override IList<IPluginLoadContext> GetPatchers()
     {
         harmonyInstance = new Harmony(Info.GUID);
-        harmonyInstance.PatchAll(Assembly.GetExecutingAssembly());
+        harmonyInstance.PatchAll(typeof(AssemblyLocationPatch));
 
         var loadContexts = new List<IPluginLoadContext>();
         foreach (var dll in Directory.GetFiles(Path.GetFullPath(Paths.PatcherPluginPath), "*.dll", SearchOption.AllDirectories))
@@ -73,7 +73,6 @@ internal class BepInExPatcherProvider : BasePatcherProvider
         return ass;
     }
 
-    [HarmonyPatch]
     public class AssemblyLocationPatch
     {
         [HarmonyPostfix]

--- a/BepInEx.PatcherProvider/BepInExPatcherProvider.cs
+++ b/BepInEx.PatcherProvider/BepInExPatcherProvider.cs
@@ -15,10 +15,14 @@ internal class BepInExPatcherProvider : BasePatcherProvider
     private static readonly Dictionary<string, string> AssemblyLocationsByFilename = new();
     private static Harmony harmonyInstance;
 
+    private static readonly bool PatchRuntimeAssembly = AccessTools.TypeByName("RuntimeAssembly")
+                                                                   ?.GetProperty("Location")?.DeclaringType?.FullName
+                                                                   ?.EndsWith("RuntimeAssembly") == true;
+
     public override IList<IPluginLoadContext> GetPatchers()
     {
         harmonyInstance = new Harmony(Info.GUID);
-        harmonyInstance.PatchAll(typeof(AssemblyLocationPatch));
+        harmonyInstance.PatchAll(PatchRuntimeAssembly ? typeof(RuntimeAssemblyLocationPatch) : typeof(AssemblyLocationPatch));
 
         var loadContexts = new List<IPluginLoadContext>();
         foreach (var dll in Directory.GetFiles(Path.GetFullPath(Paths.PatcherPluginPath), "*.dll", SearchOption.AllDirectories))
@@ -73,21 +77,36 @@ internal class BepInExPatcherProvider : BasePatcherProvider
         return ass;
     }
 
+    private static void AssemblyWorkaroundPatch(Assembly __instance, ref string __result)
+    {
+        if (!string.IsNullOrEmpty(__result))
+            return;
+
+        var name = __instance.GetName().Name;
+        if (!AssemblyLocationsByFilename.TryGetValue(name, out var location)) 
+            return;
+
+        var filenameWithoutExtension = Path.Combine(location, name);
+        __result = filenameWithoutExtension + ".dll";
+    }
+
     public class AssemblyLocationPatch
     {
         [HarmonyPostfix]
         [HarmonyPatch(typeof(Assembly), nameof(Assembly.Location), MethodType.Getter)]
         public static void AssemblyLocationWorkaround(Assembly __instance, ref string __result)
         {
-            if (!string.IsNullOrEmpty(__result))
-                return;
+            AssemblyWorkaroundPatch(__instance, ref __result);
+        }
+    }
 
-            var name = __instance.GetName().Name;
-            if (!AssemblyLocationsByFilename.TryGetValue(name, out var location)) 
-                return;
-
-            var filenameWithoutExtension = Path.Combine(location, name);
-            __result = filenameWithoutExtension + ".dll";
+    public class RuntimeAssemblyLocationPatch
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch("RuntimeAssembly", nameof(Assembly.Location), MethodType.Getter)]
+        public static void AssemblyLocationWorkaround(Assembly __instance, ref string __result)
+        {
+            AssemblyWorkaroundPatch(__instance, ref __result);
         }
     }
 }

--- a/BepInEx.PluginProvider/BepInExPluginProvider.cs
+++ b/BepInEx.PluginProvider/BepInExPluginProvider.cs
@@ -17,7 +17,7 @@ internal class BepInExPluginProvider : BasePluginProvider
     public override IList<IPluginLoadContext> GetPlugins()
     {
         harmonyInstance = new Harmony(Info.Metadata.GUID);
-        harmonyInstance.PatchAll(Assembly.GetExecutingAssembly());
+        harmonyInstance.PatchAll(typeof(AssemblyLocationPatch));
 
         var loadContexts = new List<IPluginLoadContext>();
         foreach (var dll in Directory.GetFiles(Path.GetFullPath(Paths.PluginPath), "*.dll", SearchOption.AllDirectories))
@@ -72,7 +72,6 @@ internal class BepInExPluginProvider : BasePluginProvider
         return ass;
     }
 
-    [HarmonyPatch]
     public class AssemblyLocationPatch
     {
         [HarmonyPostfix]

--- a/BepInEx.PluginProvider/BepInExPluginProvider.cs
+++ b/BepInEx.PluginProvider/BepInExPluginProvider.cs
@@ -87,7 +87,7 @@ internal class BepInExPluginProvider : BasePluginProvider
                 return;
 
             var filenameWithoutExtension = Path.Combine(location, name);
-            __result = Path.ChangeExtension(filenameWithoutExtension, ".dll");
+            __result = filenameWithoutExtension + ".dll";
         }
     }
 }

--- a/BepInEx.PluginProvider/BepInExPluginProvider.cs
+++ b/BepInEx.PluginProvider/BepInExPluginProvider.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using BepInEx.Logging;
+using HarmonyLib;
 
 namespace BepInEx.PluginProvider;
 
@@ -11,9 +12,13 @@ namespace BepInEx.PluginProvider;
 internal class BepInExPluginProvider : BasePluginProvider
 {
     private static readonly Dictionary<string, string> AssemblyLocationsByFilename = new();
+    private static Harmony harmonyInstance;
     
     public override IList<IPluginLoadContext> GetPlugins()
     {
+        harmonyInstance = new Harmony(Info.Metadata.GUID);
+        harmonyInstance.PatchAll(Assembly.GetExecutingAssembly());
+
         var loadContexts = new List<IPluginLoadContext>();
         foreach (var dll in Directory.GetFiles(Path.GetFullPath(Paths.PluginPath), "*.dll", SearchOption.AllDirectories))
         {
@@ -65,5 +70,24 @@ internal class BepInExPluginProvider : BasePluginProvider
             return null;
 
         return ass;
+    }
+
+    [HarmonyPatch]
+    public class AssemblyLocationPatch
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(Assembly), nameof(Assembly.Location), MethodType.Getter)]
+        public static void AssemblyLocationWorkaround(Assembly __instance, ref string __result)
+        {
+            if (!string.IsNullOrEmpty(__result))
+                return;
+
+            var name = __instance.GetName().Name;
+            if (!AssemblyLocationsByFilename.TryGetValue(name, out var location)) 
+                return;
+
+            var filenameWithoutExtension = Path.Combine(location, name);
+            __result = Path.ChangeExtension(filenameWithoutExtension, ".dll");
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This workarounds a regression that was observed on v6 when a plugin would do Assembly.Location and get nothing because the plugin is now loaded in memory with a provider. Only the providers knows the actual location so as a workaround for v6, this pr postfixes Assembly.Location to return the correct path if applicable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a v6 regression and blocks its next release.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested from a unity 2018.4.12 game (new mono).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
