### PR TITLE
v7: Catch BadImageFormatExceptions when reading an assembly stream

### DIFF
--- a/BepInEx.Core/Bootstrap/TypeLoader.cs
+++ b/BepInEx.Core/Bootstrap/TypeLoader.cs
@@ -274,18 +274,25 @@ public static class TypeLoader
                                            string location)
         where T : ICacheable, new()
     {
-        using var ass = AssemblyDefinition.ReadAssembly(dllMs, ReaderParameters);
-        Logger.Log(LogLevel.Debug, $"Examining '{ass.Name}'");
+        try 
+        {
+            using var ass = AssemblyDefinition.ReadAssembly(dllMs, ReaderParameters);
+            Logger.Log(LogLevel.Debug, $"Examining '{ass.Name}'");
 
-        if (!assemblyFilter?.Invoke(ass) ?? false)
+            if (!assemblyFilter?.Invoke(ass) ?? false)
+            {
+                return new List<T>();
+            }
+
+            var matches = ass.MainModule.Types
+                             .Select(t => typeSelector(t, loadContext, location))
+                             .Where(t => t != null).ToList();
+            return matches;
+        }
+        catch (BadImageFormatException)
         {
             return new List<T>();
         }
-
-        var matches = ass.MainModule.Types
-                         .Select(t => typeSelector(t, loadContext, location))
-                         .Where(t => t != null).ToList();
-        return matches;
     }
 
     /// <summary>

--- a/BepInEx.Core/Bootstrap/TypeLoader.cs
+++ b/BepInEx.Core/Bootstrap/TypeLoader.cs
@@ -274,7 +274,7 @@ public static class TypeLoader
                                            string location)
         where T : ICacheable, new()
     {
-        try 
+        try
         {
             using var ass = AssemblyDefinition.ReadAssembly(dllMs, ReaderParameters);
             Logger.Log(LogLevel.Debug, $"Examining '{ass.Name}'");
@@ -291,6 +291,11 @@ public static class TypeLoader
         }
         catch (BadImageFormatException)
         {
+            return new List<T>();
+        }
+        catch (Exception e)
+        {
+            Logger.Log(LogLevel.Error, $"An unexpected error occured when examining an assembly stream: {e}");
             return new List<T>();
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When reading plugins assembly streams, it's not possible for the default providers to know without reading the assembly if it's a native dll or not. However, if it is a native dll, exceptions would bubble up to stall the entire loading process which shouldn't happen. This PR catches the exception.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes a regression where having a native dll would cause a stray exception throw.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested on a unity 2018.4 game (new mono) and it fixed the issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
