### PR TITLE
Include DeobfuscationMap.csv.gz in ComputeHash

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -137,6 +137,8 @@ internal static partial class Il2CppInteropManager
 
     internal static string IL2CPPInteropAssemblyPath => Path.Combine(IL2CPPBasePath, "interop");
 
+    private static string RenameMapPath => Path.Combine(Paths.BepInExRootPath, "DeobfuscationMap.csv.gz");
+
     private static ILoggerFactory LoggerFactory { get; } = MSLoggerFactory.Create(b =>
     {
         b.AddProvider(new BepInExLoggerProvider())
@@ -172,6 +174,11 @@ internal static partial class Il2CppInteropManager
                 HashString(md5, Path.GetFileName(file));
                 HashFile(md5, file);
             }
+
+        if (File.Exists(RenameMapPath))
+        {
+            HashFile(md5, RenameMapPath);
+        }
 
         // Hash some common dependencies as they can affect output
         HashString(md5, typeof(InteropAssemblyGenerator).Assembly.GetName().Version.ToString());
@@ -361,11 +368,10 @@ internal static partial class Il2CppInteropManager
                                        : null,
         };
 
-        var renameMapLocation = Path.Combine(Paths.BepInExRootPath, "DeobfuscationMap.csv.gz");
-        if (File.Exists(renameMapLocation))
+        if (File.Exists(RenameMapPath))
         {
             Logger.LogInfo("Parsing deobfuscation rename mappings");
-            opts.ReadRenameMap(renameMapLocation);
+            opts.ReadRenameMap(RenameMapPath);
         }
 
         Logger.LogInfo("Generating interop assemblies");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR includes DeobfuscationMap.csv.gz content in `Il2CppInteropManager.ComputeHash()` so that `Il2CppInteropManager` regenerates interop assemblies when the deobfuscation mapping file changes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
DeobfuscationMap.csv.gz directly impacts interop assemblies since it can change the name of generated symbols.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been tested on Windows 11 32H2 with an IL2Cpp game simply by modifying the DeobfuscationMap.csv.gz and seeing if the iterop assemblies are regenerated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
