### PR TITLE
Checks if target Unity binaries archive exists before attempting download in case game's network conenction is blocked

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Security.Cryptography;

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -287,6 +287,8 @@ internal static partial class Il2CppInteropManager
         var unityVersion = UnityInfo.Version;
         var version = $"{unityVersion.Major}.{unityVersion.Minor}.{unityVersion.Build}";
         var source = UnityBaseLibrariesSource.Value.Replace("{VERSION}", version);
+        if (string.IsNullOrEmpty(source)) return;
+
         var uri = new Uri(source);
         string file = Path.GetFileName(uri.AbsolutePath);
 

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -285,7 +285,10 @@ internal static partial class Il2CppInteropManager
 
     private static void DownloadUnityAssemblies() {
         var unityVersion = UnityInfo.Version;
-        var file = $"{unityVersion.Major}.{unityVersion.Minor}.{unityVersion.Build}.zip";
+        var version = $"{unityVersion.Major}.{unityVersion.Minor}.{unityVersion.Build}";
+        var source = UnityBaseLibrariesSource.Value.Replace("{VERSION}", version);
+        var uri = new Uri(source);
+        string file = Path.GetFileName(uri.AbsolutePath);
 
         var baseFolder = Directory.CreateDirectory(UnityBaseLibsDirectory);
         baseFolder.EnumerateFiles("*.dll").Do(a=>a.Delete());
@@ -295,7 +298,6 @@ internal static partial class Il2CppInteropManager
             using var zipArchive = new ZipArchive(fStream, ZipArchiveMode.Read);
             zipArchive.ExtractToDirectory(UnityBaseLibsDirectory);
         } else {
-            var source = UnityBaseLibrariesSource.Value.Replace("{VERSION}.zip", file);
             Logger.LogMessage($"Downloading unity base libraries {source}");
             using var httpClient = new HttpClient();
             using var zipStream = httpClient.GetStreamAsync(source).GetAwaiter().GetResult();

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -296,6 +296,7 @@ internal static partial class Il2CppInteropManager
         baseFolder.EnumerateFiles("*.dll").Do(a=>a.Delete());
         var target = baseFolder.GetFiles(file).FirstOrDefault();
         if (target != null) {
+            Logger.LogMessage($"Reading unity base libraries from file {source}");
             using var fStream = target.OpenRead();
             using var zipArchive = new ZipArchive(fStream, ZipArchiveMode.Read);
             zipArchive.ExtractToDirectory(UnityBaseLibsDirectory);

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -295,7 +295,7 @@ internal static partial class Il2CppInteropManager
             using var zipArchive = new ZipArchive(fStream, ZipArchiveMode.Read);
             zipArchive.ExtractToDirectory(UnityBaseLibsDirectory);
         } else {
-            var source = UnityBaseLibrariesSource.Value + file;
+            var source = UnityBaseLibrariesSource.Value.Replace("{VERSION}.zip", file);
             Logger.LogMessage($"Downloading unity base libraries {source}");
             using var httpClient = new HttpClient();
             using var zipStream = httpClient.GetStreamAsync(source).GetAwaiter().GetResult();


### PR DESCRIPTION
## Description
This allows downloading the archive manually to unity-libs folder so that if the game is blocked by firewall, it won't throw an exception.
Perhaps another solution is to prompt the user to download from the default web browser but for now this fixes the problem for me and is easy to code (coded this ages ago, I don't even remember when).

## Motivation and Context
I block all outbounds by default so naturally none of the games can connect to the internet.

## How Has This Been Tested?
fresh game folder with 2019.4.11.f Unity
download 2019.4.11.zip to `BepInEx\unity-libs`
copy files from `bin\Unity.IL2CPP` to `BepInEx\core`
copy, from release, the dotnet runtime and everything outside BepInEx to '.\', and dobby.dll to  `BepInEx\core`
run the game once, see the archive decompressed with no more HTTP exception

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
