### PR TITLE
UnityVersion parsing and configuration

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.Common/BepInEx.Unity.Common.csproj
+++ b/Runtimes/Unity/BepInEx.Unity.Common/BepInEx.Unity.Common.csproj
@@ -6,6 +6,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\..\BepInEx.Core\BepInEx.Core.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="AssetRipper.Primitives" Version="3.1.3" />
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all"/>
         <PackageReference Include="MonoMod.Utils" Version="22.7.31.1"/>

--- a/Runtimes/Unity/BepInEx.Unity.Common/UnityInfo.cs
+++ b/Runtimes/Unity/BepInEx.Unity.Common/UnityInfo.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using AssetRipper.Primitives;
 using BepInEx.Configuration;
+using BepInEx.Logging;
 using MonoMod.Utils;
 
 [assembly: InternalsVisibleTo("BepInEx.Unity.Mono.Preloader")]
@@ -49,10 +50,12 @@ public static class UnityInfo
 
     private static readonly ConfigEntry<string> ConfigUnityVersion = ConfigFile.CoreConfig.Bind(
         "General",
-        "UnityVersion",
+        "UnityVersionOverride",
         "",
-        "Unity player version. Leave it empty to let BepInEx determine the version automatically"
+        "Unity player version override. Leave it empty to let BepInEx determine the version automatically"
     );
+
+    private static readonly ManualLogSource Logger = Logging.Logger.CreateLogSource("UnityInfo");
 
     internal static void Initialize(string unityPlayerPath, string gameDataPath)
     {
@@ -69,6 +72,7 @@ public static class UnityInfo
             }
             catch (Exception)
             {
+                Logger.LogError(string.Format("Could not parse \"{0}\" as a unity player version. Fallback to automatic version determination.", ConfigUnityVersion.Value));
                 DetermineVersion();
             }
         }

--- a/Runtimes/Unity/BepInEx.Unity.Common/UnityInfo.cs
+++ b/Runtimes/Unity/BepInEx.Unity.Common/UnityInfo.cs
@@ -123,8 +123,19 @@ public static class UnityInfo
                 fs.Position = offset;
 
                 byte b;
-                while ((b = (byte) fs.ReadByte()) != 0)
-                    sb.Append((char) b);
+                var isPrintable = true;
+                while ((b = (byte)fs.ReadByte()) != 0)
+                {
+                    var ch = (char)b;
+                    if (char.IsControl(ch))
+                    {
+                        isPrintable = false;
+                        break;
+                    }
+                    sb.Append(ch);
+                }
+                if (!isPrintable)
+                    continue;
 
                 try
                 {

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Preloader.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Preloader.cs
@@ -27,7 +27,6 @@ public static class Preloader
         {
             HarmonyBackendFix.Initialize();
             ConsoleSetOutFix.Apply();
-            UnityInfo.Initialize(Paths.ExecutablePath, Paths.GameDataPath);
 
             ConsoleManager.Initialize(false, true);
 
@@ -43,6 +42,8 @@ public static class Preloader
             RedirectStdErrFix.Apply();
 
             ChainloaderLogHelper.PrintLogInfo(Log);
+            
+            UnityInfo.Initialize(Paths.ExecutablePath, Paths.GameDataPath);
 
             Logger.Log(LogLevel.Info, $"Running under Unity {UnityInfo.Version}");
             Logger.Log(LogLevel.Info, $"Runtime version: {Environment.Version}");

--- a/Runtimes/Unity/BepInEx.Unity.Mono.Preloader/UnityPreloader.cs
+++ b/Runtimes/Unity/BepInEx.Unity.Mono.Preloader/UnityPreloader.cs
@@ -40,7 +40,6 @@ internal static class UnityPreloader
         try
         {
             HarmonyBackendFix.Initialize();
-            UnityInfo.Initialize(Paths.ExecutablePath, Paths.GameDataPath);
 
             ConsoleManager.Initialize(false, false);
             AllocateConsole();
@@ -58,6 +57,9 @@ internal static class UnityPreloader
             Logger.Listeners.Add(PreloaderLog);
 
             ChainloaderLogHelper.PrintLogInfo(Log);
+
+            UnityInfo.Initialize(Paths.ExecutablePath, Paths.GameDataPath);
+            
             Log.Log(LogLevel.Info, $"Running under Unity {UnityInfo.Version}");
             Log.Log(LogLevel.Info, $"CLR runtime version: {Environment.Version}");
             Log.Log(LogLevel.Info, $"Supports SRE: {Utility.CLRSupportsDynamicAssemblies}");


### PR DESCRIPTION
## Description
It's essential for BepInEx to determine the unity version to work properly. This PR brings up a fix for the specific case when parsing of unity version goes wrong. Additionaly I've added an option to the config file, so the user can always set the version manually, if parsing silently fails again.

## Motivation and Context
Generally `BepInEx.Unity.Common.UnityInfo` works fine and determines the version correctly. But some games can have their files encrypted. For this case you would expect `AssetRipper.Primitives.UnityVersion::Parse` to fail. But actually it can "successfully" parse the encrypted bytes. The reason for this is that `UnityVersion::Parse` uses simple regexes under the hood and these regexes are not very strict. For example if you pass `THISISNOTAUNITYVERSION3!@#$%^&*(` to the `UnityVersion::Parse` it will successfully parse `3.0.0f1` version, since it has `3` somewhere within it.

This is exactly what happened to me. `UnityInfo` tried to parse the encrypted `globalgamemanagers` file and "successfully" parsed a unity version . This is how my file looks like:
![image](https://github.com/user-attachments/assets/72a5f9ff-f870-44bc-9746-8f895a7a3771)
UnityInfo tries to get a CString starting from 0x14 offset. Accidentally there is a `3` character in there.

I believe, there is no ideal fix to handle all possible cases automatically. But I tried to improve it a little. My fix is to skip version parsing, if there are non-printable characters in the CString.

Also, I'm not sure what was the motivation for adding the `GlobalMetadataPath` option to the config file, but this option really helped me to point BepIn to the decrypted file. Inspired by this option, I've added the UnityVersion field to the config file.

## How Has This Been Tested?
Smoke tests on the game with encypted files. Also tested on a "game" (actually just empty unity build) with usual non-encrypted files. Both of them run on the `2019.4.40f1` unity player version.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
