### PR TITLE
Switch Build.csproj TargetFramework to net8.0

### DIFF
--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     </PropertyGroup>


### PR DESCRIPTION
Fixes CI broken by net6.0 being deprecated.