### PR TITLE
v6 - Bump Cpp2IL to pre-release.19

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/BepInEx.Unity.IL2CPP.csproj
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/BepInEx.Unity.IL2CPP.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" IncludeAssets="compile" PrivateAssets="all"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" IncludeAssets="compile" PrivateAssets="all"/>
         <PackageReference Include="MonoMod.RuntimeDetour" Version="22.7.31.1"/>
-        <PackageReference Include="Samboy063.Cpp2IL.Core" Version="2022.1.0-pre-release.18"/>
+        <PackageReference Include="Samboy063.Cpp2IL.Core" Version="2022.1.0-pre-release.19"/>
     </ItemGroup>
 
     <!-- CopyLocalLockFileAssemblies causes to also output shared assemblies: https://github.com/NuGet/Home/issues/4837#issuecomment-354536302 -->


### PR DESCRIPTION

## Description
Needed to support the latest Unity engine versions. Tested in a few games, works with no apparent regressions.
