### PR TITLE
AllowDerived classes of BepInPlugin

### DIFF
--- a/BepInEx.Core/Contract/Attributes.cs
+++ b/BepInEx.Core/Contract/Attributes.cs
@@ -14,6 +14,7 @@ namespace BepInEx;
 
 /// <summary>
 ///     This attribute denotes that a class is a plugin, and specifies the required metadata.
+///     If you Inherit this class, the first 3 arguments of your constructor must be unchanged - (GUID, Name, Version)
 /// </summary>
 [AttributeUsage(AttributeTargets.Class)]
 public class BepInPlugin : Attribute


### PR DESCRIPTION
allow 
```cs
class x: BepInPlugin {
    x(string GUID, string Name, string Version, string newArg):base(GUID,Name,Version) { }
}
[x("real.guid", "MyPlugin", "0.0.1", "example new field")]
Plugin : basePlugin {}
```
## Description
When the preloader scanning assemblies use .Resolve() recursively on types in order to find if any are derived from BepInPlugin

## Motivation and Context
This is useful for when modding communities need some extra game-specific metadata associated with a plugin.
yes they could create a derived type of BasePlugin with some extra abstract getters but this is cleaner.


## How Has This Been Tested?
This has been tested in the context of [ResoniteModdig/BepisLoader](https://github.com/ResoniteModding/BepisLoader)
with [BepInExResoniteShim](https://github.com/ResoniteModding/BepInExResoniteShim) as the plugin creating a derived type of BepInPlugin
any of [my BepisLoader mods](https://github.com/EIA485?tab=repositories&q=Neos&type=source&language=&sort=) as the plugin using said derived type

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project. - not sure. could not find a code style document
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## Notes:
if plugins are using a class defined in another plugin they should use [BepInDependency] to ensure their Dependency is loaded first.
