### PR TITLE
Fix(IL2CPP): Correct handling of IL2CPPInteropAssembliesPath

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -113,8 +113,8 @@ internal static partial class Il2CppInteropManager
 
     private static readonly ManualLogSource Logger = BepInEx.Logging.Logger.CreateLogSource("InteropManager");
     
-    private static string _il2cppInteropAssemblyPath;
     private static string _il2cppBasePath;
+    private static string _il2cppInteropAssemblyPath;
 
     private static bool initialized;
 
@@ -130,12 +130,14 @@ internal static partial class Il2CppInteropManager
         {
             if (_il2cppBasePath != null)
                 return _il2cppBasePath;
-            _il2cppBasePath = Path.GetDirectoryName(IL2CPPInteropAssemblyPath);
+
+            var path = Utility.GetCommandLineArgValue("--unhollowed-path") ?? IL2CPPInteropAssembliesPath.Value;
+            _il2cppBasePath = path.Replace("{BepInEx}", Paths.BepInExRootPath)
+                                  .Replace("{ProcessName}", Paths.ProcessName);
+    
             return _il2cppBasePath;
         }
     }
-
-    private static string UnityBaseLibsDirectory => Path.Combine(IL2CPPBasePath, "unity-libs");
 
     internal static string IL2CPPInteropAssemblyPath
     {
@@ -143,16 +145,17 @@ internal static partial class Il2CppInteropManager
         {
             if (_il2cppInteropAssemblyPath != null)
                 return _il2cppInteropAssemblyPath;
-            var path = Utility.GetCommandLineArgValue("--unhollowed-path") ?? IL2CPPInteropAssembliesPath.Value;
-            _il2cppInteropAssemblyPath = path.Replace("{BepInEx}", Paths.BepInExRootPath)
-                                              .Replace("{ProcessName}", Paths.ProcessName);
+    
+            _il2cppInteropAssemblyPath = IL2CPPBasePath;
+    
             if (IL2CPPInteropAssembliesPath.Value.Trim() == "{BepInEx}")
-            {
                 _il2cppInteropAssemblyPath = Path.Combine(_il2cppInteropAssemblyPath, "interop");
-            }
+    
             return _il2cppInteropAssemblyPath;
         }
     }
+
+    private static string UnityBaseLibsDirectory => Path.Combine(IL2CPPBasePath, "unity-libs");
     
     private static string RenameMapPath => Path.Combine(Paths.BepInExRootPath, "DeobfuscationMap.csv.gz");
 

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -112,8 +112,9 @@ internal static partial class Il2CppInteropManager
          .ToString());
 
     private static readonly ManualLogSource Logger = BepInEx.Logging.Logger.CreateLogSource("InteropManager");
-
-    private static string il2cppInteropBasePath;
+    
+    private static string _il2cppInteropAssemblyPath;
+    private static string _il2cppBasePath;
 
     private static bool initialized;
 
@@ -123,21 +124,36 @@ internal static partial class Il2CppInteropManager
 
     private static string HashPath => Path.Combine(IL2CPPInteropAssemblyPath, "assembly-hash.txt");
 
-    private static string IL2CPPBasePath {
-        get {
-            if (il2cppInteropBasePath != null)
-                return il2cppInteropBasePath;
-            var path = Utility.GetCommandLineArgValue("--unhollowed-path") ?? IL2CPPInteropAssembliesPath.Value;
-            il2cppInteropBasePath = path.Replace("{BepInEx}", Paths.BepInExRootPath)
-                                     .Replace("{ProcessName}", Paths.ProcessName);
-            return il2cppInteropBasePath;
+    private static string IL2CPPBasePath
+    {
+        get
+        {
+            if (_il2cppBasePath != null)
+                return _il2cppBasePath;
+            _il2cppBasePath = Path.GetDirectoryName(IL2CPPInteropAssemblyPath);
+            return _il2cppBasePath;
         }
     }
 
     private static string UnityBaseLibsDirectory => Path.Combine(IL2CPPBasePath, "unity-libs");
 
-    internal static string IL2CPPInteropAssemblyPath => Path.Combine(IL2CPPBasePath, "interop");
-
+    internal static string IL2CPPInteropAssemblyPath
+    {
+        get
+        {
+            if (_il2cppInteropAssemblyPath != null)
+                return _il2cppInteropAssemblyPath;
+            var path = Utility.GetCommandLineArgValue("--unhollowed-path") ?? IL2CPPInteropAssembliesPath.Value;
+            _il2cppInteropAssemblyPath = path.Replace("{BepInEx}", Paths.BepInExRootPath)
+                                              .Replace("{ProcessName}", Paths.ProcessName);
+            if (IL2CPPInteropAssembliesPath.Value.Trim() == "{BepInEx}")
+            {
+                _il2cppInteropAssemblyPath = Path.Combine(_il2cppInteropAssemblyPath, "interop");
+            }
+            return _il2cppInteropAssemblyPath;
+        }
+    }
+    
     private static string RenameMapPath => Path.Combine(Paths.BepInExRootPath, "DeobfuscationMap.csv.gz");
 
     private static ILoggerFactory LoggerFactory { get; } = MSLoggerFactory.Create(b =>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This change corrects how the `IL2CPPInteropAssembliesPath` setting is handled.  
Previously, it was always treated as a base directory and a hardcoded `/interop` subfolder was appended, which caused incorrect path resolution when users provided a complete or custom path.  

The updated logic now treats `IL2CPPInteropAssembliesPath` as the *final* path when customised. The `/interop` suffix is only appended when the configuration remains at its default value of `{BepInEx}`, ensuring backward compatibility while allowing full control over path structure.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> 
<!--- If it fixes an open issue, please link to the issue here. -->
This fix resolves an issue where specifying a custom interop assemblies path (such as `{ProcessName}` or an absolute directory) resulted in redundant or nested paths like `MyGame/MyGame/interop`.  
The change improves flexibility and predictability in how IL2CPP interop assemblies are located, making configuration more intuitive for users.

## How Has This Been Tested?
- Verified correct behaviour with default `{BepInEx}` configuration.  
- Tested custom absolute paths and relative templates (e.g., `{ProcessName}`).  
- Confirmed interop assemblies load correctly from user-defined directories.  


## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  

## Checklist
- [x] My code follows the code style of this project.  
- [ ] My change requires a change to the documentation.  
- [ ] I have updated the documentation accordingly.  
