### PR TITLE
Fix assembly preloading overriding preloader patches

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -400,12 +400,13 @@ internal static partial class Il2CppInteropManager
         Parallel.ForEach(files, file =>
         {
             if (!file.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)) return;
-            if (file.Equals("netstandard.dll", StringComparison.OrdinalIgnoreCase)) return;
-            if (file.Equals("Il2Cppnetstandard.dll", StringComparison.OrdinalIgnoreCase)) return;
+            var name = Path.GetFileNameWithoutExtension(file);
+            if (name.Equals("netstandard", StringComparison.OrdinalIgnoreCase)) return;
+            if (name.Equals("Il2Cppnetstandard", StringComparison.OrdinalIgnoreCase)) return;
             try
             {
                 // Do not use LoadFrom since it overrides preloader patches
-                Assembly.Load(AssemblyDefinition.ReadAssembly(file).FullName);
+                Assembly.Load(name);
                 Interlocked.Increment(ref loaded);
             }
             catch (Exception e)


### PR DESCRIPTION
## Description
Preloading always loaded assemblies from file which discarded any preloader-patched versions of these assemblies.

## How Has This Been Tested?
Tested locally by patching in a crash and seeing if it happens. Works fine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
