### PR TITLE
Cache downloaded base libraries in the `unity-libs` directory

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -299,7 +299,7 @@ internal static partial class Il2CppInteropManager
         {
             // Check if URI is valid before attempting download
             if (!uriIsValid)
-                throw new ArgumentException($"Unity base libraries source \"{source}\" is not a valid URL. Please provide a valid HTTP or HTTPS URL in the configuration. Filenames are not supported for downloads.");
+                throw new ArgumentException($"Unity base libraries source \"{source}\" is not a valid URL and the .zip file does not exist locally. Either provide a valid HTTP/HTTPS URL, or place the .zip file in the unity-libs directory.");
 
             Logger.LogMessage($"Downloading unity base libraries from {source}");
             using var httpClient = new HttpClient();

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -60,7 +60,7 @@ internal static partial class Il2CppInteropManager
      new StringBuilder()
          .AppendLine("URL to a ZIP file with managed Unity base libraries. They are used by Il2CppInterop to generate interop assemblies.")
          .AppendLine("The URL can include {VERSION} template which will be replaced with the game's Unity engine version.")
-         .AppendLine("If a .zip file with the specified name already exists in unity-libs, it will be used instead of downloading a new copy.")
+         .AppendLine("If a .zip file with the same filename as the URL (after template replacement) already exists in unity-libs, it will be used instead of downloading a new copy.")
          .AppendLine("If you want to ensure BepInEx doesn't try to connect to the internet set this to only contain the .zip file name.")
          .ToString());
 

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -298,7 +298,7 @@ internal static partial class Il2CppInteropManager
         if (!File.Exists(zipFilePath))
         {
             // Check if URI is valid before attempting download
-            if(!uriIsValid)
+            if (!uriIsValid)
                 throw new ArgumentException($"Unity base libraries source \"{source}\" is not a valid URL. Please provide a valid HTTP or HTTPS URL in the configuration. Filenames are not supported for downloads.");
 
             Logger.LogMessage($"Downloading unity base libraries from {source}");

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -292,7 +292,12 @@ internal static partial class Il2CppInteropManager
         var baseFolder = Directory.CreateDirectory(UnityBaseLibsDirectory);
         baseFolder.EnumerateFiles("*.dll").Do(a=>a.Delete());
 
-        var zipFilePath = Path.Combine(baseFolder.FullName, Path.GetFileName(source));
+        string fileName;
+        if (Uri.TryCreate(source, UriKind.Absolute, out var uri) && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+            fileName = Path.GetFileName(uri.AbsolutePath);
+        else
+            fileName = Path.GetFileName(source);
+        var zipFilePath = Path.Combine(baseFolder.FullName, fileName);
         if (!File.Exists(zipFilePath))
         {
             // Check if URI is valid before attempting download

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -61,7 +61,7 @@ internal static partial class Il2CppInteropManager
          .AppendLine("URL to a ZIP file with managed Unity base libraries. They are used by Il2CppInterop to generate interop assemblies.")
          .AppendLine("The URL can include {VERSION} template which will be replaced with the game's Unity engine version.")
          .AppendLine("If a .zip file with the same filename as the URL (after template replacement) already exists in unity-libs, it will be used instead of downloading a new copy.")
-         .AppendLine("If you want to ensure BepInEx doesn't try to connect to the internet, set this to only contain the .zip file name.")
+         .AppendLine("If you want to ensure BepInEx doesn't try to connect to the internet, set this to only the .zip filename (without a URL) and manually place the file in the unity-libs directory.")
          .ToString());
 
     private static readonly ConfigEntry<string> ConfigUnhollowerDeobfuscationRegex = ConfigFile.CoreConfig.Bind(

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -61,7 +61,7 @@ internal static partial class Il2CppInteropManager
          .AppendLine("URL to a ZIP file with managed Unity base libraries. They are used by Il2CppInterop to generate interop assemblies.")
          .AppendLine("The URL can include {VERSION} template which will be replaced with the game's Unity engine version.")
          .AppendLine("If a .zip file with the same filename as the URL (after template replacement) already exists in unity-libs, it will be used instead of downloading a new copy.")
-         .AppendLine("If you want to ensure BepInEx doesn't try to connect to the internet set this to only contain the .zip file name.")
+         .AppendLine("If you want to ensure BepInEx doesn't try to connect to the internet, set this to only contain the .zip file name.")
          .ToString());
 
     private static readonly ConfigEntry<string> ConfigUnhollowerDeobfuscationRegex = ConfigFile.CoreConfig.Bind(

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -312,7 +312,7 @@ internal static partial class Il2CppInteropManager
             catch
             {
                 // Delete the incomplete file to avoid issues on next startup
-                File.Delete(zipFilePath);
+                try { File.Delete(zipFilePath); } catch { }
                 throw;
             }
         }


### PR DESCRIPTION
## Description
After downloading base libraries, save the .zip to disk so that they do not have to be downloaded again if interop needs to be regenerated.

Loading base libraries from a .zip file was already implemented but the file had to be placed there manually, now it's automatic.

## Motivation and Context
This should alleviate the common issue of being unable to start BepInEx because base libraries fail to be downloaded. Game-specific redistributions will now (hopefully) contain this zip file by default, making it unnecessary for users to attempt a download.

Some of the issues that this works around: #407 #515 #599 #941 

This will also allow users to ensure BepInEx is fully off-line by removing the download URL (only need to leave the filename).

## How Has This Been Tested?
Tested by removing interop and ensuring a new copy is not downloaded if the zip already exists, otherwise it is downloaded and saved to the zip. No regressions found.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
