### PR TITLE
Fix wine/proton monomod being loaded before bepinex

### DIFF
--- a/BepInEx.Preloader.Core/PlatformUtils.cs
+++ b/BepInEx.Preloader.Core/PlatformUtils.cs
@@ -127,7 +127,11 @@ internal static class PlatformUtils
                 current |= Platform.ARM;
         }
 
-        PlatformHelper.Current = current;
+        try {
+            PlatformHelper.Current = current;
+        } catch(Exception e) {
+            // TODO: monomod complains otherwise (on wine/proton)
+        }
     }
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
monomod sets platform.current, then bepinex tries to set it, but you can only set it once, so it throws

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
normal bepinex 5 didn't work, due to a infinite hangup, so i just went and said "well lets try 6"; everything was fine except for this singular line of code which made monomod raise an exception (i guess loading order in wine was different or whatever)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
opened the game
bepinex now works

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
