### PR TITLE
v5 - Fix for unity 2022.3.62f3 not having get_graphicsDeviceID

### DIFF
--- a/BepInEx/Bootstrap/Chainloader.cs
+++ b/BepInEx/Bootstrap/Chainloader.cs
@@ -48,7 +48,11 @@ namespace BepInEx.Bootstrap
 				var prop = AccessTools.PropertyGetter(typeof(Application), "isBatchMode");
 				if (prop != null)
 					return (bool) prop.Invoke(null, null);
-				return SystemInfo.graphicsDeviceID == 0;
+				try {
+					return SystemInfo.graphicsDeviceID == 0;
+				} catch(Exception e) {
+					return false; //Unity 2022.3.62f3 for example doesn't have such method
+				}
 			}
 		}
 

--- a/BepInEx/Bootstrap/Chainloader.cs
+++ b/BepInEx/Bootstrap/Chainloader.cs
@@ -50,8 +50,18 @@ namespace BepInEx.Bootstrap
 					return (bool) prop.Invoke(null, null);
 				try {
 					return SystemInfo.graphicsDeviceID == 0;
-				} catch(Exception e) {
-					return false; //Unity 2022.3.62f3 for example doesn't have such method
+				}
+				catch (MissingMethodException)
+				{
+					return false; // Unity 2022.3.62f3 for example doesn't have such method
+				}
+				catch (MissingFieldException)
+				{
+					return false; // Unity 2022.3.62f3 for example doesn't have such field
+				}
+				catch (MissingMemberException)
+				{
+					return false; // Unity 2022.3.62f3 for example doesn't have such member
 				}
 			}
 		}

--- a/BepInEx/Bootstrap/Chainloader.cs
+++ b/BepInEx/Bootstrap/Chainloader.cs
@@ -48,21 +48,13 @@ namespace BepInEx.Bootstrap
 				var prop = AccessTools.PropertyGetter(typeof(Application), "isBatchMode");
 				if (prop != null)
 					return (bool) prop.Invoke(null, null);
-				try {
-					return SystemInfo.graphicsDeviceID == 0;
-				}
-				catch (MissingMethodException)
-				{
-					return false; // Unity 2022.3.62f3 for example doesn't have such method
-				}
-				catch (MissingFieldException)
-				{
-					return false; // Unity 2022.3.62f3 for example doesn't have such field
-				}
-				catch (MissingMemberException)
-				{
-					return false; // Unity 2022.3.62f3 for example doesn't have such member
-				}
+				// Some Unity builds may miss this property, see 
+				// https://docs.unity3d.com/2022.3/Documentation/ScriptReference/SystemInfo-graphicsDeviceID.html
+				var prop2 = AccessTools.PropertyGetter(typeof(SystemInfo), "graphicsDeviceID");
+				if (prop2 != null)
+					return ((int) prop2.Invoke(null, null)) == 0;
+				
+				return false;
 			}
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fixes error with missing method

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
allows one to run bepinex5

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
yeah

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
