### PR TITLE
fix: Prevent shell launch script from splitting on spaces in passed-through arguments

### DIFF
--- a/Runtimes/Unity/Doorstop/run_bepinex_il2cpp.sh
+++ b/Runtimes/Unity/Doorstop/run_bepinex_il2cpp.sh
@@ -263,7 +263,11 @@ while :; do
             if [ -z "$1" ]; then
                 break
             fi
-            rest_args="$rest_args $1"
+            # Wrap all passed-through arguments in double quotes.
+            # This is a lazy but effective means of preventing the shell
+            # from splitting spaces where it shouldn't (such as spaces
+            # in a path).
+            rest_args="$rest_args \"$1\""
         ;;
     esac
     shift
@@ -300,4 +304,5 @@ else
 fi
 
 # shellcheck disable=SC2086
-exec "$executable_path" $rest_args
+eval "$executable_path" "$rest_args"
+exit $?


### PR DESCRIPTION
## Description
(From commit description)

Before this change, the `exec`s in the launch script would split on
spaces within arguments. This was particularly problematic for dealing
with paths containing spaces, which would be split into multiple
arguments and cause execution to fail.

This fix has two parts:
1. Wrap passed-in arguments with double-quotes.
2. Use `eval` rather than `exec`.

By using eval rather than exec, this could have security implications -
in particular, this could allow for shell injection via the arguments
passed through the script. This could be fixed by using bashisms and/or
by more complex shell code that I'm not immediately familiar with.
However, given this script is probably going to be started either by
Steam or directly by the user and is directly intended to launch an
arbitrary executable (a game), it seems reasonable to me to simply
trust the input rather than do something more complicated.

## Motivation and Context
When launched targeting an executable path containing a space, the game will fail to launch as the shell will split the path into two separate malformed arguments. I ran into this issue launching Vampire Survivors when launching from Steam (launch args `./run_bepinex.sh %command%`). As an example, here is the logs of a launch, using `set -x` to debug the existing shell script.


```
chdir "/mnt/opensuse/home/user/.local/share/Steam/steamapps/common/Vampire Survivors"
Game Recording - would start recording game 1794680, but recording for this game is disabled
Adding process 24447 for gameID 1794680
ERROR: ld.so: object '/home/user/.local/share/Steam/ubuntu12_32/gameoverlayrenderer.so' from LD_PRELOAD cannot be preloaded (wrong ELF class: ELFCLASS32): ignored.
ERROR: ld.so: object '/home/user/.local/share/Steam/ubuntu12_32/gameoverlayrenderer.so' from LD_PRELOAD cannot be preloaded (wrong ELF class: ELFCLASS32): ignored.
+ executable_name=
+ enabled=1
+ target_assembly=BepInEx/core/BepInEx.Unity.IL2CPP.dll
+ boot_config_override=
+ ignore_disable_switch=0
+ dll_search_path_override=
+ debug_enable=0
+ debug_start_server=0
+ debug_address=127.0.0.1:10000
+ debug_suspend=0
+ coreclr_path=dotnet/libcoreclr
+ corlib_dir=dotnet
+ '[' -- = SteamLaunch ']'
+ '[' -x /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper ']'
+ executable_name=/home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper
+ echo 'Target executable: /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper'
Target executable: /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper
+ shift
+ '[' -z /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper ']'
+ '[' '!' -x /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper ']'
+ a=/./run_bepinex.sh
+ a=/.
+ a=.
+ a=.
++ cd .
++ pwd -P
pid 24448 != 24447, skipping destruction (fork without exec?)
+ BASEDIR='/mnt/opensuse/home/user/.local/share/Steam/steamapps/common/Vampire Survivors'
+ arch=
+ executable_path=
+ lib_extension=
++ uname -s
ERROR: ld.so: object '/home/user/.local/share/Steam/ubuntu12_32/gameoverlayrenderer.so' from LD_PRELOAD cannot be preloaded (wrong ELF class: ELFCLASS32): ignored.
+ os_type=Linux
+ case ${os_type} in
+ executable_path=/home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper
+ echo /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper
+ grep '^/.*$'
pid 24450 != 24447, skipping destruction (fork without exec?)
ERROR: ld.so: object '/home/user/.local/share/Steam/ubuntu12_32/gameoverlayrenderer.so' from LD_PRELOAD cannot be preloaded (wrong ELF class: ELFCLASS32): ignored.
/home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper
+ lib_extension=so
++ resolve_executable_path /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper
+++ abs_path /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper
+++++ dirname /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper
ERROR: ld.so: object '/home/user/.local/share/Steam/ubuntu12_32/gameoverlayrenderer.so' from LD_PRELOAD cannot be preloaded (wrong ELF class: ELFCLASS32): ignored.
++++ cd /home/user/.local/share/Steam/ubuntu12_32
++++ pwd
pid 24454 != 24447, skipping destruction (fork without exec?)
++++ basename /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper
ERROR: ld.so: object '/home/user/.local/share/Steam/ubuntu12_32/gameoverlayrenderer.so' from LD_PRELOAD cannot be preloaded (wrong ELF class: ELFCLASS32): ignored.
+++ echo /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper
pid 24453 != 24447, skipping destruction (fork without exec?)
++ e_path=/home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper
++ '[' -L /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper ']'
++ echo /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper
pid 24452 != 24447, skipping destruction (fork without exec?)
+ executable_path=/home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper
+ echo /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper
/home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper
++ LD_PRELOAD=
++ file -b /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper
+ file_out='ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.24, BuildID[sha1]=ea89f5e18bf7940624ced33d537b4ab4a4ce31cc, not stripped'
+ case "${file_out}" in
+ arch=x64
+ :
+ case "$1" in
+ '[' -z -- ']'
+ rest_args=' --'
+ shift
+ :
+ case "$1" in
+ '[' -z /home/user/.local/share/Steam/ubuntu12_32/reaper ']'
+ rest_args=' -- /home/user/.local/share/Steam/ubuntu12_32/reaper'
+ shift
+ :
+ case "$1" in
+ '[' -z SteamLaunch ']'
+ rest_args=' -- /home/user/.local/share/Steam/ubuntu12_32/reaper SteamLaunch'
+ shift
+ :
+ case "$1" in
+ '[' -z AppId=1794680 ']'
+ rest_args=' -- /home/user/.local/share/Steam/ubuntu12_32/reaper SteamLaunch AppId=1794680'
+ shift
+ :
+ case "$1" in
+ '[' -z -- ']'
+ rest_args=' -- /home/user/.local/share/Steam/ubuntu12_32/reaper SteamLaunch AppId=1794680 --'
+ shift
+ :
+ case "$1" in
+ '[' -z '/mnt/opensuse/home/user/.local/share/Steam/steamapps/common/Vampire Survivors/VampireSurvivors.exe' ']'
+ rest_args=' -- /home/user/.local/share/Steam/ubuntu12_32/reaper SteamLaunch AppId=1794680 -- /mnt/opensuse/home/user/.local/share/Steam/steamapps/common/Vampire Survivors/VampireSurvivors.exe'
+ shift
+ :
+ case "$1" in
+ '[' -z '' ']'
+ break
+ export DOORSTOP_ENABLED=1
+ DOORSTOP_ENABLED=1
+ export DOORSTOP_TARGET_ASSEMBLY=BepInEx/core/BepInEx.Unity.IL2CPP.dll
+ DOORSTOP_TARGET_ASSEMBLY=BepInEx/core/BepInEx.Unity.IL2CPP.dll
+ export DOORSTOP_IGNORE_DISABLED_ENV=0
+ DOORSTOP_IGNORE_DISABLED_ENV=0
+ export DOORSTOP_MONO_DLL_SEARCH_PATH_OVERRIDE=
+ DOORSTOP_MONO_DLL_SEARCH_PATH_OVERRIDE=
+ export DOORSTOP_MONO_DEBUG_ENABLED=0
+ DOORSTOP_MONO_DEBUG_ENABLED=0
+ export DOORSTOP_MONO_DEBUG_START_SERVER=0
+ DOORSTOP_MONO_DEBUG_START_SERVER=0
+ export DOORSTOP_MONO_DEBUG_ADDRESS=127.0.0.1:10000
+ DOORSTOP_MONO_DEBUG_ADDRESS=127.0.0.1:10000
+ export DOORSTOP_MONO_DEBUG_SUSPEND=0
+ DOORSTOP_MONO_DEBUG_SUSPEND=0
+ export DOORSTOP_CLR_RUNTIME_CORECLR_PATH=dotnet/libcoreclr.so
+ DOORSTOP_CLR_RUNTIME_CORECLR_PATH=dotnet/libcoreclr.so
+ export DOORSTOP_CLR_CORLIB_DIR=dotnet
+ DOORSTOP_CLR_CORLIB_DIR=dotnet
+ doorstop_directory='/mnt/opensuse/home/user/.local/share/Steam/steamapps/common/Vampire Survivors/'
+ doorstop_name=libdoorstop.so
+ export 'LD_LIBRARY_PATH=/mnt/opensuse/home/user/.local/share/Steam/steamapps/common/Vampire Survivors/:dotnet:/home/user/.local/share/Steam/ubuntu12_32/steam-runtime/pinned_libs_32:/home/user/.local/share/Steam/ubuntu12_32/steam-runtime/pinned_libs_64:/opt/cuda/lib64:/opt/cuda/nvvm/lib64:/opt/intel/oneapi/compiler/latest/lib:/usr/lib32:/usr/lib/libfakeroot:/usr/lib:/home/user/.local/share/Steam/ubuntu12_32/steam-runtime/lib/i386-linux-gnu:/home/user/.local/share/Steam/ubuntu12_32/steam-runtime/usr/lib/i386-linux-gnu:/home/user/.local/share/Steam/ubuntu12_32/steam-runtime/lib/x86_64-linux-gnu:/home/user/.local/share/Steam/ubuntu12_32/steam-runtime/usr/lib/x86_64-linux-gnu:/home/user/.local/share/Steam/ubuntu12_32/steam-runtime/lib:/home/user/.local/share/Steam/ubuntu12_32/steam-runtime/usr/lib:/mnt/opensuse/home/user/.local/share/Steam/steamapps/common/Vampire Survivors'
+ LD_LIBRARY_PATH='/mnt/opensuse/home/user/.local/share/Steam/steamapps/common/Vampire Survivors/:dotnet:/home/user/.local/share/Steam/ubuntu12_32/steam-runtime/pinned_libs_32:/home/user/.local/share/Steam/ubuntu12_32/steam-runtime/pinned_libs_64:/opt/cuda/lib64:/opt/cuda/nvvm/lib64:/opt/intel/oneapi/compiler/latest/lib:/usr/lib32:/usr/lib/libfakeroot:/usr/lib:/home/user/.local/share/Steam/ubuntu12_32/steam-runtime/lib/i386-linux-gnu:/home/user/.local/share/Steam/ubuntu12_32/steam-runtime/usr/lib/i386-linux-gnu:/home/user/.local/share/Steam/ubuntu12_32/steam-runtime/lib/x86_64-linux-gnu:/home/user/.local/share/Steam/ubuntu12_32/steam-runtime/usr/lib/x86_64-linux-gnu:/home/user/.local/share/Steam/ubuntu12_32/steam-runtime/lib:/home/user/.local/share/Steam/ubuntu12_32/steam-runtime/usr/lib:/mnt/opensuse/home/user/.local/share/Steam/steamapps/common/Vampire Survivors'
+ '[' -z :/home/user/.local/share/Steam/ubuntu12_32/gameoverlayrenderer.so:/home/user/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so ']'
+ export LD_PRELOAD=libdoorstop.so::/home/user/.local/share/Steam/ubuntu12_32/gameoverlayrenderer.so:/home/user/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so
+ LD_PRELOAD=libdoorstop.so::/home/user/.local/share/Steam/ubuntu12_32/gameoverlayrenderer.so:/home/user/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so
+ export 'DYLD_LIBRARY_PATH=/mnt/opensuse/home/user/.local/share/Steam/steamapps/common/Vampire Survivors/:'
+ DYLD_LIBRARY_PATH='/mnt/opensuse/home/user/.local/share/Steam/steamapps/common/Vampire Survivors/:'
+ '[' -z '' ']'
+ export DYLD_INSERT_LIBRARIES=libdoorstop.so
+ DYLD_INSERT_LIBRARIES=libdoorstop.so
+ exec /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper -- /home/user/.local/share/Steam/ubuntu12_32/reaper SteamLaunch AppId=1794680 -- /mnt/opensuse/home/user/.local/share/Steam/steamapps/common/Vampire Survivors/VampireSurvivors.exe
ERROR: ld.so: object '/home/user/.local/share/Steam/ubuntu12_32/gameoverlayrenderer.so' from LD_PRELOAD cannot be preloaded (wrong ELF class: ELFCLASS32): ignored.
ERROR: ld.so: object 'libdoorstop.so' from LD_PRELOAD cannot be preloaded (wrong ELF class: ELFCLASS64): ignored.
ERROR: ld.so: object '/home/user/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so' from LD_PRELOAD cannot be preloaded (wrong ELF class: ELFCLASS64): ignored.
pid 24458 != 24447, skipping destruction (fork without exec?)
WARNING: discarding _NET_WM_PID 5 as invalid for X11 window - use specialized XCB_X11_TO_PID function!
Adding process 24449 for gameID 1794680
Adding process 24451 for gameID 1794680
Adding process 24455 for gameID 1794680
Adding process 24456 for gameID 1794680
Game Recording - game stopped [gameid=1794680]
Removing process 24456 for gameID 1794680
Removing process 24455 for gameID 1794680
Removing process 24451 for gameID 1794680
Removing process 24449 for gameID 1794680
Removing process 24447 for gameID 1794680
```

Adding double-quotes around each arg make `set -x` more illustrative of how the string is getting split:

```
+ exec /home/user/.local/share/Steam/ubuntu12_32/steam-launch-wrapper '"--"' '"/home/user/.local/share/Steam/ubuntu12_32/reaper"' '"SteamLaunch"' '"AppId=1794680"' '"--"' '"/mnt/opensuse/home/user/.local/share/Steam/steamapps/common/Vampire' 'Survivors/VampireSurvivors.exe"'
```

As demonstrated, the space-containing path to the final executable is split into two arguments, which causes the game to fail to launch.

Unfortunately, simpler changes don't seem to work. Simply wrapping `$rest_args` in quotes collapses all the remaining args into a single (long) argument, and wrapping each arg in double-quotes alone doesn't work since `exec` will pass the double-quotes through, mangling the arguments. Both are needed to wrap spaces correctly (by using double quotes), then prune them away in the actual args passed through to the child process (eval).

I'm not sure there's a better (simple) way of doing this - fundamentally, it seems like the script is trying to pass through some, but not all of its own arguments (eating the flags intended for it rather than the executable). While the script "knows" a given argument containing a space is a single argument, it only knows this because it's passed in (effectively) to its own variable. By combining all of these variables into a single `rest_args`, this information is lost. Injecting double quotes retains this information, but then we require shell-like behavior in order to prune these double-quotes since we don't want the executed process to actually receive them. The easiest solution to this would be an array, but POSIX shells don't support arrays, and I don't think it's a good idea to inject bashisms just for this.

## How Has This Been Tested?
The game was run with these changes and launched successfully. The `set -x` output was also examined to ensure that things look correct. This *should* be safe for games in general unless games are passing special characters as arguments, namely double-quotes of their own.

I can run additional tests and/or add additional safeguards, but I don't know what other Unity-on-Linux games I have available.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
