### PR TITLE
Fix Wine-related preloader error

### DIFF
--- a/BepInEx.Preloader.Core/PlatformUtils.cs
+++ b/BepInEx.Preloader.Core/PlatformUtils.cs
@@ -80,7 +80,12 @@ internal static class PlatformUtils
                 if (wineGetVersion != IntPtr.Zero)
                 {
                     current |= Platform.Wine;
-                    var getVersion = wineGetVersion.AsDelegate<GetWineVersionDelegate>();
+                    // It's not safe to use the AsDelegate() extension method here because:
+                    //  - It comes from the MonoMod.Utils.DynDll class, defined in MonoMod.Common.
+                    //  - The DynDll class has a static constructor that reads PlatformHelper.Current.
+                    //  - Reading from that property freezes it: subsequent writes will throw an exception.
+                    //  - This method only sets PlatformHelper.Current at the very end.
+                    var getVersion = Marshal.GetDelegateForFunctionPointer(wineGetVersion, typeof(GetWineVersionDelegate)) as GetWineVersionDelegate;
                     WineVersion = getVersion();
                 }
             }


### PR DESCRIPTION
## Description
My comment in the code explains most of what was happening.
To slightly abbreviate, using the `AsDelegate` extension method was subtly causing `PlatformHelper.Current` to lock itself unexpectedly.

Alternative approaches that I wouldn't mind switching to if maintainers prefer:
- Define our own copy of `AsDelegate`, avoiding the unintended semi-unrelated side effect.
    - I didn't go for this because I wasn't sure where to put it, and it would be a little tricky to be sure which version is actually being resolved unless the name is different.
- Move the `WineVersion` code to the end, *after* the main `PlatformHelper.Current` assignment.
    - I didn't go for this because it would have required either hoisting the `wineGetVersion` variable out or duplicating the call(s) to `LoadLibrary` and/or `GetProcAddress`, both of which seemed messy.

Fixes #702 
Fixes #1201 
Supersedes #1234 

Related code:
[The place where the exception gets thrown](https://github.com/MonoMod/MonoMod.Common/blob/ea24867bb49621372eaf53b2ef552cbf488af55b/Utils/PlatformHelper.cs#L173)
[The definition of the helper method](https://github.com/MonoMod/MonoMod.Common/blob/ea24867bb49621372eaf53b2ef552cbf488af55b/Utils/DynDll.cs#L23)
[The static constructor with the unintended side effect](https://github.com/MonoMod/MonoMod.Common/blob/ea24867bb49621372eaf53b2ef552cbf488af55b/Utils/DynDll.Manual.cs#L132)

## Motivation and Context
BIE 6 doesn't work under Wine/Proton. I'm not the first to run into this issue, but hopefully I'll be the last.

## How Has This Been Tested?
I was able to run Katamari Damacy REROLL (a Mono game, I know, but this bug and fix seem runtime-independent) on my Steam Deck and confirm not only that BepInEx gets past the preloader stage, but that it can load one of my mods for the game.

## Screenshots:
<img width="1105" height="491" alt="image" src="https://github.com/user-attachments/assets/45ce7764-5e97-4792-87f5-b8ca9bdffbd4" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
