### PR TITLE
v5: Fix log writer errors for Unity 6

### DIFF
--- a/BepInEx/Logging/UnityLogListener.cs
+++ b/BepInEx/Logging/UnityLogListener.cs
@@ -31,8 +31,10 @@ namespace BepInEx.Logging
 			}
 
 			// Fix for Unity 6. Both methods previously targeted no longer use internal calls
-			if (WriteStringToUnityLog == null) {
-				try {
+			if (WriteStringToUnityLog == null) 
+			{
+				try 
+				{
 					var type = Type.GetType("UnityEngine.UnityLogWriter, UnityEngine.CoreModule");
 					var methodInfo = type.GetMethod("WriteStringToUnityLogImpl", 
 						BindingFlags.Static | BindingFlags.NonPublic, 

--- a/BepInEx/Logging/UnityLogListener.cs
+++ b/BepInEx/Logging/UnityLogListener.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -28,6 +28,20 @@ namespace BepInEx.Logging
 
 				WriteStringToUnityLog = (Action<string>)Delegate.CreateDelegate(typeof(Action<string>), methodInfo);
 				break;
+			}
+
+			// Fix for Unity 6. Both methods previously targeted no longer use internal calls
+			if (WriteStringToUnityLog == null) {
+				try {
+					var type = Type.GetType("UnityEngine.UnityLogWriter, UnityEngine.CoreModule");
+					var methodInfo = type.GetMethod("WriteStringToUnityLogImpl", 
+						BindingFlags.Static | BindingFlags.NonPublic, 
+						null, 
+						new Type[] { typeof(string) }, 
+						null);
+					methodInfo.Invoke(null, new object[] { "" });
+					WriteStringToUnityLog = (Action<string>)Delegate.CreateDelegate(typeof(Action<string>), methodInfo);
+				} catch { }
 			}
 
 			if (WriteStringToUnityLog == null)


### PR DESCRIPTION
In newer versions of unity the methods that were used to write to the unity log have changed. I have created a fix that will get the new method and assign the delegate.

Fixes #1256 and #1158

## Description
If the original attempts fail use reflection to retrieve the new log method inside the original unity engine dll.

## Motivation and Context
Errors were being made. I just got this after testing the new Atlyss beta and saw there were other reports.

## How Has This Been Tested?
Supermarket Together and Atlyss (Beta branch) were launched with bepinex installed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
