### PR TITLE
Improved support for IL2CPP metadata v23-106 (Unity 6+)

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/BepInEx.Unity.IL2CPP.csproj
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/BepInEx.Unity.IL2CPP.csproj
@@ -15,14 +15,14 @@
     <ItemGroup>
         <PackageReference Include="HarmonyX" Version="2.10.2" />
         <PackageReference Include="Iced" Version="1.21.0" />
-        <PackageReference Include="Il2CppInterop.Generator" Version="1.5.0-ci.620"/>
-        <PackageReference Include="Il2CppInterop.HarmonySupport" Version="1.5.0-ci.620"/>
+        <PackageReference Include="Il2CppInterop.Generator" Version="1.5.1-ci.829"/>
+        <PackageReference Include="Il2CppInterop.HarmonySupport" Version="1.5.1-ci.829"/>
         <PackageReference Include="Il2CppInterop.ReferenceLibs" Version="1.0.0" IncludeAssets="compile" PrivateAssets="all"/>
-        <PackageReference Include="Il2CppInterop.Runtime" Version="1.5.0-ci.620"/>
+        <PackageReference Include="Il2CppInterop.Runtime" Version="1.5.1-ci.829"/>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" IncludeAssets="compile" PrivateAssets="all"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" IncludeAssets="compile" PrivateAssets="all"/>
         <PackageReference Include="MonoMod.RuntimeDetour" Version="22.7.31.1"/>
-        <PackageReference Include="Samboy063.Cpp2IL.Core" Version="2022.1.0-pre-release.19"/>
+        <PackageReference Include="Samboy063.Cpp2IL.Core" Version="2022.1.0-development.1452"/>
     </ItemGroup>
 
     <!-- CopyLocalLockFileAssemblies causes to also output shared assemblies: https://github.com/NuGet/Home/issues/4837#issuecomment-354536302 -->


### PR DESCRIPTION
Provides improved support for IL2CPP metadata v23-106 (Unity 6+)

<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated dependencies on Il2cppInterop and Cpp2IL for latest metadata support

## Motivation and Context
Without this, IL2CPP games built for metadata newer than v31 are failing. It is common to find games using metadata v39 at present.

## How Has This Been Tested?
As this only affects the Unity IL2CPP, I have tested the build against multiple IL2CPP games old and new, which seem to be working without issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
