### PR TITLE
v5: Fix HarmonyX version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Unity plugin framework
 
 ## Used libraries
 - [NeighTools/UnityDoorstop](https://github.com/NeighTools/UnityDoorstop) - 4.5.0 ([33dab9a](https://github.com/NeighTools/UnityDoorstop/commit/33dab9a6733862eb81869ff08431d9478b28784b))
-- [BepInEx/HarmonyX](https://github.com/BepInEx/HarmonyX) - 2.7.0 ([2537257](https://github.com/BepInEx/HarmonyX/commit/253725768e59b0e1ea90105cdbcc4a0a477422c7))
+- [BepInEx/HarmonyX](https://github.com/BepInEx/HarmonyX) - 2.9.0 ([31d794f](https://github.com/BepInEx/HarmonyX/commit/31d794f3affce55fa87c99efac7dae23a126cf52))
 - [MonoMod/MonoMod](https://github.com/MonoMod/MonoMod) - v21.12.13.01 ([ede81f4](https://github.com/MonoMod/MonoMod/commit/ede81f48924d58abf05359409fad740fe2b0dfb5))
 - [jbevain/cecil](https://github.com/jbevain/cecil) - 0.10.4 ([98ec890](https://github.com/jbevain/cecil/commit/98ec890d44643ad88d573e97be0e120435eda732))
 


### PR DESCRIPTION
The version of HarmonyX that is currently distributed with BepInEx 5 is v2.9.0. This can be confirmed by downloading the latest release of BIE5 and looking at the version of `0Harmony.dll` or by looking at [the version referenced in the Harmony wrapper submodule](https://github.com/BepInEx/BepInEx.Harmony/blob/d4cdcb4cdeac14a0b77012165f5f5a9f5032a9fa/HarmonyXInterop/HarmonyXInterop.csproj).

The README incorrectly states that BIE5 is still on HarmonyX 2.7.0 and points to the wrong commit. This PR seeks to rectify that.