### PR TITLE
v5: Fix crash on macOS arm64: wrap XTermFix and ConsoleSetOutFix in Utility.TryDo

### DIFF
--- a/BepInEx.Preloader/Entrypoint.cs
+++ b/BepInEx.Preloader/Entrypoint.cs
@@ -10,6 +10,12 @@ namespace BepInEx.Preloader
 {
 	internal static class PreloaderRunner
 	{
+		/// <summary>
+		///     Exceptions thrown by XTermFix.Apply() and ConsoleSetOutFix.Apply() during early preloader init,
+		///     stored for deferred logging in <see cref="Preloader.Run"/> once the logger is available.
+		/// </summary>
+		internal static Exception XTermFixException;
+		internal static Exception ConsoleSetOutFixException;
 		// This is a list of important assemblies in BepInEx core folder that should be force-loaded
 		// Some games can ship these assemblies in Managed folder, in which case assembly resolving bypasses our LocalResolve
 		// On the other hand, renaming these assemblies is not viable because 3rd party assemblies
@@ -62,8 +68,14 @@ namespace BepInEx.Preloader
 		{
 			if (Preloader.ConfigApplyRuntimePatches.Value)
 			{
-				XTermFix.Apply();
-				ConsoleSetOutFix.Apply();
+				// These fixes must run before ConsoleManager.Initialize (which opens the terminal),
+				// so they cannot be placed inside Preloader.Run(). Wrap them individually so that
+				// a failure on one platform (e.g. macOS arm64, where MonoMod's ILHook throws a
+				// NullReferenceException in DetourHelper.GetIdentifiable) does not prevent BepInEx
+				// from initializing at all. Exceptions are stored for deferred logging once the
+				// BepInEx logger is available in Preloader.Run().
+				Utility.TryDo(() => XTermFix.Apply(), out XTermFixException);
+				Utility.TryDo(() => ConsoleSetOutFix.Apply(), out ConsoleSetOutFixException);
 			}
 
 			Preloader.Run();

--- a/BepInEx.Preloader/Preloader.cs
+++ b/BepInEx.Preloader/Preloader.cs
@@ -73,6 +73,12 @@ namespace BepInEx.Preloader
 				Logger.LogInfo($"Supports SRE: {Utility.CLRSupportsDynamicAssemblies}");
 				Logger.LogInfo($"System platform: {PlatformHelper.Current}");
 
+				if (PreloaderRunner.XTermFixException != null)
+					Logger.LogWarning($"Failed to apply XTermFix runtime patch. See more info in the output log. Error message: {PreloaderRunner.XTermFixException.Message}");
+
+				if (PreloaderRunner.ConsoleSetOutFixException != null)
+					Logger.LogWarning($"Failed to apply ConsoleSetOutFix runtime patch. See more info in the output log. Error message: {PreloaderRunner.ConsoleSetOutFixException.Message}");
+
 				if (runtimePatchException != null)
 					Logger.LogWarning($"Failed to apply runtime patches for Mono. See more info in the output log. Error message: {runtimePatchException.Message}");
 


### PR DESCRIPTION
## Problem

On macOS arm64 (Apple Silicon — M1/M2/M3/M4), BepInEx fails to initialize completely with no mods loading. The root cause is in `MonoMod.RuntimeDetour`:

```
System.NullReferenceException: Object reference not set to an instance of an object
  at MonoMod.RuntimeDetour.DetourHelper.GetIdentifiable(MethodBase method)
  at MonoMod.RuntimeDetour.ILHook..ctor(...)
  at HarmonyLib.Public.Patching.ManagedMethodPatcher.DetourTo(...)
  at BepInEx.Preloader.RuntimeFixes.ConsoleSetOutFix.Apply()
  at BepInEx.Preloader.PreloaderRunner.PreloaderMain()
  at BepInEx.Preloader.PreloaderRunner.PreloaderPreMain()
  at Doorstop.Entrypoint.Start()
```

On the macOS arm64 Mono runtime, `DetourHelper.GetIdentifiable()` returns `null` for certain methods (e.g. `Console.SetOut`, `TermInfoReader` methods). `ILHook`'s constructor does not guard against this null return, so the exception propagates all the way out of `PreloaderMain()`, through Doorstop's outer catch, and BepInEx never gets to `Preloader.Run()`. The game launches but with zero mods active.

This affects **all macOS arm64 users** (anyone on Apple Silicon running any game with BepInEx 5.x).

## Root cause

`PreloaderMain()` calls `XTermFix.Apply()` and `ConsoleSetOutFix.Apply()` directly with no exception handling. By contrast, `UnityPatches.Apply()` in `Preloader.Run()` is already protected with `Utility.TryDo()`.

These two fixes must run before `ConsoleManager.Initialize` (to intercept the terminal before it opens), so they cannot simply be relocated into `Run()`. The fix is to wrap each with `Utility.TryDo()` in place, and store any exception for deferred logging once the BepInEx logger is available in `Run()`.

## Changes

- **`Entrypoint.cs`**: Replace bare `XTermFix.Apply()` / `ConsoleSetOutFix.Apply()` calls with `Utility.TryDo()`, storing exceptions in internal static fields.
- **`Preloader.cs`**: After `Logger.InitializeInternalLoggers()`, log any stored exceptions as warnings — consistent with the existing `runtimePatchException` warning for `UnityPatches`.

The diff is 20 lines, touches only those two files, and introduces no new patterns — everything uses `Utility.TryDo()` which is already the established idiom for non-fatal runtime patches.

## Verification

Tested on an M4 MacBook Pro (macOS 15.3.1, arm64) with Valheim + BepInExPack_Valheim 5.4.2333:

**Before this fix** — preloader log shows unhandled exception, BepInEx does not load:
```
System.NullReferenceException at DetourHelper.GetIdentifiable
  → ConsoleSetOutFix.Apply() → PreloaderMain() → Doorstop.Entrypoint.Start()
```
Game launches without any mods.

**After this fix** — BepInEx log shows:
```
[Info   ] System platform: Bits64, MacOS, ARM
[Warning] Failed to apply ConsoleSetOutFix runtime patch. Error message: IL Compile Error (unknown location)
[Message] Preloader started
[Message] Preloader finished
[Message] Chainloader started
[Info   ] 27 plugins to load
[Info   ] Loading [serverblankpassword 1.0.0.0]
...
```
All 27 plugins load successfully on Apple Silicon.

## Notes

The underlying MonoMod issue (null return from `GetIdentifiable` on arm64 Mono) would ideally be fixed in MonoMod itself. However, since MonoMod 22.x is in maintenance mode and BepInEx 5.x bundles a pinned MonoMod version, the defensive wrapping in BepInEx is the practical fix for the 5.x LTS branch.