### PR TITLE
Make [Obsolete] text for GetConfigEntries more actionable

### DIFF
--- a/BepInEx/Configuration/ConfigFile.cs
+++ b/BepInEx/Configuration/ConfigFile.cs
@@ -45,7 +45,7 @@ namespace BepInEx.Configuration
 		/// If you want to access and modify an existing setting then use <see cref="AddSetting{T}(ConfigDefinition,T,ConfigDescription)"/> 
 		/// instead with no description.
 		/// </summary>
-		[Obsolete("Use Values instead")]
+		[Obsolete("Use ((IDictionary<ConfigDefinition, ConfigEntryBase>)configFile).Values instead")]
 		public ConfigEntryBase[] GetConfigEntries()
 		{
 			lock (_ioLock)


### PR DESCRIPTION
## Description

Due to a missing public visibility modifier for Values on 5-lts branch, the existing message text in [Obsolete] attribute is misleading

C# strangely allows to implement as interface and access interface methods through casting, but hide them from direct access via normal means.

Note that the visibility modifier has already been added on the master branch back in 2022 in e473f08e0a85fffd818f310c783458037a079ded

Closes #1305

## How Has This Been Tested?

Write this in another file, for example in _ConfigEntryBase.cs_, and observe the errors and warning that it produces:

```cs
			_ = configFile.GetConfigEntries();
			_ = configFile.Values;
			_ = ((IDictionary<ConfigDefinition, ConfigEntryBase>)configFile).Values;
```

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
