### PR TITLE
Fix misleading error label for Finished event handlers

### DIFF
--- a/BepInEx.Core/Bootstrap/BaseChainloader.cs
+++ b/BepInEx.Core/Bootstrap/BaseChainloader.cs
@@ -315,7 +315,15 @@ public abstract class BaseChainloader<TPlugin>
             var plugins = DiscoverPlugins();
             Logger.Log(LogLevel.Info, $"{plugins.Count} plugin{(plugins.Count == 1 ? "" : "s")} to load");
             LoadPlugins(plugins);
-            Finished?.Invoke();
+
+            try
+            {
+                Finished?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                Logger.Log(LogLevel.Error, $"Error occurred in a Chainloader.Finished event handler: {ex}");
+            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Problem

`BaseChainloader.Execute()` invokes the `Finished` event inside the `try`/`catch` block that handles plugin-loading errors. When a listener subscribed to `BaseChainloader.Finished` throws, the exception is logged as:

> Error occurred loading plugins: ...

even though the failure happens *after* loading and is unrelated to plugin loading. This is misleading for plugin authors debugging post-load logic (reported in #842).

## Fix

Move `Finished?.Invoke()` into its own `try`/`catch` with an accurate message (`Error occurred in a Chainloader.Finished event handler: ...`).

Control flow is otherwise preserved:
- `Finished` still fires only after `LoadPlugins` succeeds.
- A throwing listener is still caught (no startup crash).
- `Chainloader startup complete` is still logged afterwards.

## Testing

- `dotnet build BepInEx.sln -c Release -p:GeneratePackageOnBuild=false` — 0 errors.
- The repo has no unit-test harness for the chainloader path; this is a minimal, in-scope control-flow correction per CONTRIBUTING.

Fixes #842