### PR TITLE
Skip missing search directories to fix preloader DirectoryNotFoundException

### DIFF
--- a/BepInEx.Core/Utility.cs
+++ b/BepInEx.Core/Utility.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Security.Cryptography;
 using System.Text;
+using BepInEx.Logging;
 using Mono.Cecil;
 
 namespace BepInEx;
@@ -417,10 +418,13 @@ public static class Utility
         var result = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
         foreach (var directory in directories)
         {
-            // A configured search directory (e.g. a missing unstripped_corlib) may not exist;
-            // skip it instead of letting Directory.GetFiles throw DirectoryNotFoundException.
+            // A configured search directory (e.g. a missing unstripped_corlib) may not exist; warn and skip it
+            // instead of letting Directory.GetFiles throw DirectoryNotFoundException.
             if (!Directory.Exists(directory))
+            {
+                Logger.Log(LogLevel.Warning, $"Skipping search directory that does not exist: {directory}");
                 continue;
+            }
 
             foreach (var file in Directory.GetFiles(directory, pattern))
             {

--- a/BepInEx.Core/Utility.cs
+++ b/BepInEx.Core/Utility.cs
@@ -416,11 +416,18 @@ public static class Utility
     {
         var result = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
         foreach (var directory in directories)
-        foreach (var file in Directory.GetFiles(directory, pattern))
         {
-            var fileName = Path.GetFileName(file);
-            if (!result.ContainsKey(fileName))
-                result[fileName] = file;
+            // A configured search directory (e.g. a missing unstripped_corlib) may not exist;
+            // skip it instead of letting Directory.GetFiles throw DirectoryNotFoundException.
+            if (!Directory.Exists(directory))
+                continue;
+
+            foreach (var file in Directory.GetFiles(directory, pattern))
+            {
+                var fileName = Path.GetFileName(file);
+                if (!result.ContainsKey(fileName))
+                    result[fileName] = file;
+            }
         }
 
         return result.Values;


### PR DESCRIPTION
## Problem

`Utility.GetUniqueFilesInDirectories` iterates each supplied directory and calls `Directory.GetFiles(directory, pattern)` **without checking that the directory exists**. When one of the configured search paths is absent — most commonly the optional `unstripped_corlib` directory beside the game — `GetFiles` throws and the preloader aborts:

```
DirectoryNotFoundException: Could not find a part of the path '...\<Game>\unstripped_corlib'.
  at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(...)
  ...
```

The game then fails to launch ("could not run preloader"). Reported independently for Valheim in #710, #698 and #694 (identical stack trace, different drive letters).

## Fix

Skip directories that don't exist before enumerating them, and log a warning (`Skipping search directory that does not exist: <path>`) so the skip is visible rather than silent. This matches the `Directory.Exists` guards already present in the sibling helpers `TryResolveDllAssembly` and `AddCecilPlatformAssemblies` in the same file — `GetUniqueFilesInDirectories` was simply missing the same check.

## Testing

- `dotnet build BepInEx.sln -c Release -p:GeneratePackageOnBuild=false` — 0 errors (all TFMs).
- A missing directory in the list is now skipped (with a warning logged) instead of throwing; existing directories are unaffected.

Fixes #710
Fixes #698
Fixes #694
