### PR TITLE
Give actionable error when Unity base-libraries download fails

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Il2CppInteropManager.cs
@@ -303,17 +303,34 @@ internal static partial class Il2CppInteropManager
 
             Logger.LogMessage($"Downloading unity base libraries from {source}");
             using var httpClient = new HttpClient();
-            using var zipStream = httpClient.GetStreamAsync(uri).GetAwaiter().GetResult();
+
+            Stream zipStream;
             try
             {
-                using var writeStream = new FileStream(zipFilePath, FileMode.Create, FileAccess.Write, FileShare.None);
-                zipStream.CopyTo(writeStream);
+                zipStream = httpClient.GetStreamAsync(uri).GetAwaiter().GetResult();
             }
-            catch
+            catch (Exception e)
             {
-                // Delete the incomplete file to avoid issues on next startup
-                try { File.Delete(zipFilePath); } catch { }
-                throw;
+                throw new IOException(
+                    $"Failed to download Unity base libraries for Unity {unityVersion} from {source}: {e.Message}. " +
+                    $"Base libraries for this Unity version may not be available on the server yet. Download a matching " +
+                    $"base-libraries .zip and place it in the \"{UnityBaseLibsDirectory}\" (unity-libs) directory, or set " +
+                    $"the [IL2CPP] UnityBaseLibrariesSource config option to a valid URL.", e);
+            }
+
+            using (zipStream)
+            {
+                try
+                {
+                    using var writeStream = new FileStream(zipFilePath, FileMode.Create, FileAccess.Write, FileShare.None);
+                    zipStream.CopyTo(writeStream);
+                }
+                catch
+                {
+                    // Delete the incomplete file to avoid issues on next startup
+                    try { File.Delete(zipFilePath); } catch { }
+                    throw;
+                }
             }
         }
 


### PR DESCRIPTION
## Problem

When BepInEx (IL2CPP) cannot download the Unity base libraries — most commonly a **404** for a Unity version not yet hosted on `unity.bepinex.dev` — `HttpClient.GetStreamAsync` throws and the exception is **uncaught** in `DownloadUnityAssemblies`. The user only sees a cryptic top-level:

```
[Error :InteropManager] Failed to generate Il2Cpp interop assemblies: System.Net.Http.HttpRequestException: Response status code does not indicate success: 404 (Not Found).
```

…and the game fails to launch, even though a local fallback already exists (dropping the .zip into the `unity-libs` directory, or overriding `[IL2CPP] UnityBaseLibrariesSource`). Nothing in the error tells the user that.

This failure mode recurs across many reports for different Unity versions, e.g. #1295, #1084, #986, #941, #515.

## Fix

Catch the download failure and rethrow with an actionable message that names the Unity version, the URL, and both workarounds:

> Failed to download Unity base libraries for Unity <ver> from <url>: <reason>. Base libraries for this Unity version may not be available on the server yet. Download a matching base-libraries .zip and place it in the "<unity-libs>" directory, or set the [IL2CPP] UnityBaseLibrariesSource config option to a valid URL.

Scope is intentionally limited to the error/guidance — it does **not** change which versions the server hosts. It turns a dead-end crash into a self-serviceable one for the whole cluster.

## Testing

- `dotnet build BepInEx.sln -c Release -p:GeneratePackageOnBuild=false` — 0 errors.
- The stream is still disposed and a partial file still cleaned up on copy failure (behaviour preserved); only the download call is now wrapped.

Refs #1295, #1084, #986, #941, #515