### PR TITLE
Set MonoMod PlatformHelper.Current via reflection to avoid MethodAccessException

### DIFF
--- a/BepInEx.Preloader.Core/PlatformUtils.cs
+++ b/BepInEx.Preloader.Core/PlatformUtils.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using BepInEx.Logging;
 using MonoMod.Utils;
 
 namespace BepInEx.Preloader.Core;
@@ -132,7 +133,25 @@ internal static class PlatformUtils
                 current |= Platform.ARM;
         }
 
-        PlatformHelper.Current = current;
+        // Set via reflection so that a runtime MonoMod.Utils whose PlatformHelper.Current setter
+        // is inaccessible to this assembly does not throw MethodAccessException at a direct call
+        // site (a version mismatch between the compiled and loaded MonoMod.Utils). Informing
+        // MonoMod of the platform is best-effort -- it falls back to its own detection -- so this
+        // must never take down the preloader.
+        try
+        {
+            typeof(PlatformHelper)
+                .GetProperty("Current", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                ?.GetSetMethod(true)
+                ?.Invoke(null, new object[] { current });
+        }
+        catch (Exception e)
+        {
+            // Non-fatal: MonoMod falls back to its own platform detection if this assignment fails.
+            // Logged (not silently swallowed) so the cause is visible when debugging.
+            PreloaderLogger.Log.Log(LogLevel.Debug,
+                                    $"Could not set MonoMod PlatformHelper.Current ({e.GetType().Name}); MonoMod will detect the platform itself.");
+        }
     }
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]


### PR DESCRIPTION
## Problem

`PlatformUtils.SetPlatform()` ends by assigning `PlatformHelper.Current = current` directly. When the `MonoMod.Utils` actually loaded at runtime exposes that setter as **inaccessible** to BepInEx (a version mismatch between the `MonoMod.Utils` BepInEx compiled against and the one loaded), the JIT rejects the call site:

```
MethodAccessException: Method `MonoMod.Utils.PlatformHelper.set_Current(MonoMod.Utils.Platform)` is inaccessible from method `BepInEx.Preloader.PlatformUtils.SetPlatform()`
```

…and the **preloader aborts before the game starts**. Reported across several environments, e.g. #817, #774, #717, #416.

## Fix

Assign through the **reflected** setter (`GetSetMethod(true).Invoke(...)`), which is not subject to the compile-time accessibility check that triggers `MethodAccessException`. Treat it as best-effort: if the assignment still fails (e.g. a future MonoMod removes/renames the member, or it is already frozen), MonoMod falls back to its own platform detection instead of crashing the preloader.

`SetPlatform` already determines `current` correctly; this only changes **how** that value is handed to MonoMod.

## Testing

- `dotnet build BepInEx.sln -c Release -p:GeneratePackageOnBuild=false` — 0 errors (all TFMs).
- The reflected set is equivalent to the direct assignment on a matching MonoMod, and no longer throws on a mismatched one.

Refs #817, #774, #717, #416