### PR TITLE
Harden the plugin type-loader cache against corruption

### DIFF
--- a/BepInEx.Core/Bootstrap/TypeLoader.cs
+++ b/BepInEx.Core/Bootstrap/TypeLoader.cs
@@ -174,7 +174,7 @@ public static class TypeLoader
             }
             catch (Exception e)
             {
-                Logger.Log(LogLevel.Error, e);
+                Logger.Log(LogLevel.Error, $"Error examining '{dll}': {e}");
             }
 
         if (cacheName != null)
@@ -231,6 +231,9 @@ public static class TypeLoader
         {
             Logger.Log(LogLevel.Warning,
                        $"Failed to load cache \"{cacheName}\"; skipping loading cache. Reason: {e.Message}.");
+            // A read failure may have left `result` partially populated; the contract is to
+            // return null so the caller does a full disk re-scan rather than trust a partial cache.
+            return null;
         }
 
         return result;
@@ -258,7 +261,9 @@ public static class TypeLoader
 
             var path = Path.Combine(Paths.CachePath, $"{cacheName}_typeloader.dat");
 
-            using var bw = new BinaryWriter(File.OpenWrite(path));
+            // FileMode.Create truncates an existing file; File.OpenWrite does not, so a shorter
+            // new cache would leave stale tail bytes that corrupt the next read.
+            using var bw = new BinaryWriter(new FileStream(path, FileMode.Create, FileAccess.Write));
             bw.Write(entries.Count);
 
             foreach (var kv in entries)


### PR DESCRIPTION
Three corruption-resilience fixes to the plugin type-loader cache (`BepInEx.Core/Bootstrap/TypeLoader.cs`). Build green across `net35`/`net46`/`net6`.

## `LoadAssemblyCache` returns a partial cache on a corrupt read (silent missing plugins)

`result` is populated entry-by-entry inside the `try`. If a `BinaryReader` read fails partway (truncated/corrupt `.dat`, `EndOfStreamException`), the `catch` logs a warning and then falls through to `return result` - handing back a **partially-populated** dictionary. But the method's own doc says *"If no cache is defined, return null"*, and `FindPluginTypes` trusts a non-null cache (skips disk re-scan for cached hashes). So a corrupt cache silently skips re-scanning - and thus loading - some plugins. Fix: `return null;` from the `catch` so the caller does a full re-scan.

## `SaveAssemblyCache` does not truncate (poisons the cache)

`File.OpenWrite` uses `FileMode.OpenOrCreate` and does **not** truncate. If the new cache is shorter than the previous one, stale tail bytes remain and corrupt the next read - which then trips the bug above and abandons the cache for the whole session. Fix: `new FileStream(path, FileMode.Create, FileAccess.Write)`.

## `FindPluginTypes` error log omits the DLL path

The generic `catch (Exception e)` logged only `e`, with no indication of which assembly failed. Every other log in the loop interpolates `dll`; this one didn't. Fix: `$"Error examining '{dll}': {e}"`.