### PR TITLE
Hash the UTF-8 byte length in HashStrings, not the char count

### DIFF
--- a/BepInEx.Core/Utility.cs
+++ b/BepInEx.Core/Utility.cs
@@ -330,7 +330,12 @@ public static class Utility
         using var md5 = MD5.Create();
 
         foreach (var str in strings)
-            md5.TransformBlock(Encoding.UTF8.GetBytes(str), 0, str.Length, null, 0);
+        {
+            // Count UTF-8 bytes, not UTF-16 chars: str.Length under-counts for any non-ASCII
+            // input, so only a prefix of the bytes would be hashed (a silently wrong hash).
+            var bytes = Encoding.UTF8.GetBytes(str);
+            md5.TransformBlock(bytes, 0, bytes.Length, null, 0);
+        }
 
         md5.TransformFinalBlock(new byte[0], 0, 0);
 


### PR DESCRIPTION
`HashStrings` feeds the UTF-8 byte array to `MD5.TransformBlock` but passes `str.Length` (the UTF-16 **char** count) as the byte count:

```csharp
md5.TransformBlock(Encoding.UTF8.GetBytes(str), 0, str.Length, null, 0);
```

For any string containing non-ASCII characters the UTF-8 array is longer than `str.Length`, so only a prefix of the bytes is hashed - a silently wrong hash. The in-tree caller `DoorstopEntrypoint` hashes the process path into the global startup-mutex id, so on any non-ASCII install path the mutex id is wrong and the duplicate-start guard is defeated.

Fix: materialise the bytes once and hash `bytes.Length`. For ASCII-only inputs the byte count equals the char count, so behaviour is unchanged there. Build green across `net35`/`net46`/`net6`.