### PR TITLE
Set the console codepage to ensure correct text display regardless of encoding

### DIFF
--- a/BepInEx.Core/Console/Windows/ConsoleEncoding/ConsoleEncoding.cs
+++ b/BepInEx.Core/Console/Windows/ConsoleEncoding/ConsoleEncoding.cs
@@ -41,7 +41,7 @@ internal partial class ConsoleEncoding : Encoding
     public override int GetByteCount(char[] chars, int index, int count)
     {
         WriteCharBuffer(chars, index, count);
-        var result = WideCharToMultiByte(_codePage, 0, chars, count, _zeroByte, 0, IntPtr.Zero, IntPtr.Zero);
+        var result = WideCharToMultiByte(_codePage, 0, _charBuffer, count, _zeroByte, 0, IntPtr.Zero, IntPtr.Zero);
         return result;
     }
 
@@ -50,7 +50,7 @@ internal partial class ConsoleEncoding : Encoding
         var byteCount = GetByteCount(chars, charIndex, charCount);
         WriteCharBuffer(chars, charIndex, charCount);
         ExpandByteBuffer(byteCount);
-        _ = WideCharToMultiByte(_codePage, 0, chars, charCount, _byteBuffer, byteCount, IntPtr.Zero,
+        _ = WideCharToMultiByte(_codePage, 0, _charBuffer, charCount, _byteBuffer, byteCount, IntPtr.Zero,
                                 IntPtr.Zero);
         var readCount = Math.Min(bytes.Length, byteCount);
         ReadByteBuffer(bytes, byteIndex, readCount);
@@ -60,7 +60,7 @@ internal partial class ConsoleEncoding : Encoding
     public override int GetCharCount(byte[] bytes, int index, int count)
     {
         WriteByteBuffer(bytes, index, count);
-        var result = MultiByteToWideChar(_codePage, 0, bytes, count, _zeroChar, 0);
+        var result = MultiByteToWideChar(_codePage, 0, _byteBuffer, count, _zeroChar, 0);
         return result;
     }
 
@@ -69,7 +69,7 @@ internal partial class ConsoleEncoding : Encoding
         var charCount = GetCharCount(bytes, byteIndex, byteCount);
         WriteByteBuffer(bytes, byteIndex, byteCount);
         ExpandCharBuffer(charCount);
-        _ = MultiByteToWideChar(_codePage, 0, bytes, byteCount, _charBuffer, charCount);
+        _ = MultiByteToWideChar(_codePage, 0, _byteBuffer, byteCount, _charBuffer, charCount);
         var readCount = Math.Min(chars.Length, charCount);
         ReadCharBuffer(chars, charIndex, readCount);
         return readCount;

--- a/BepInEx.Core/Console/Windows/WindowsConsoleDriver.cs
+++ b/BepInEx.Core/Console/Windows/WindowsConsoleDriver.cs
@@ -92,8 +92,9 @@ internal class WindowsConsoleDriver : IConsoleDriver
         // Make sure of ConsoleEncoding helper class because on some Monos
         // Encoding.GetEncoding throws NotImplementedException on most codepages
         // NOTE: We don't set Console.OutputEncoding because it resets any existing Console.Out writers
-        if (!useManagedEncoder)
-            ConsoleEncoding.ConsoleCodePage = codepage;
+        // Always set the console output codepage so the Windows console interprets bytes correctly,
+        // regardless of whether we use a managed encoder or ConsoleEncoding to produce those bytes.
+        ConsoleEncoding.ConsoleCodePage = codepage;
 
         // If stdout exists, write to it, otherwise make it the same as console out
         // Not sure if this is needed? Does the original Console.Out still work?


### PR DESCRIPTION
# Beginning with Fix Chinese Character Encoding (Mojibake) in Console Output

## Description
This PR fixes an issue where Chinese (and other non-ASCII) characters appear as garbled text in the BepInEx log console. The fix addresses two encoding bugs in the Windows console driver and encoding layer.

- Bug 1 [Critical] — Console output codepage not set on IL2CPP/.NET runtimes
In WindowsConsoleDriver.CreateConsole(), the Windows console output codepage was only set when useManagedEncoder  false (the Unity Mono path). On IL2CPP, .NET Framework, and .NET CoreCLR (useManagedEncoder == true), the console
codepage was never changed from the system default. On Chinese Windows (default codepage 936/GBK), the StreamWriter would write UTF-8 bytes to CONOUT$, but the console would interpret those bytes as GBK, producing garbled output instead of Chinese characters.

The fix removes the if (!useManagedEncoder) guard so SetConsoleOutputCP(codepage) is always called, ensuring the
Windows console interprets bytes with the same encoding the StreamWriter uses to produce them.

- Bug 2 [Correctness] — ConsoleEncoding ignored char/index offsets in Win32 API calls

In ConsoleEncoding.cs, all four override methods (GetByteCount, GetBytes, GetCharCount, GetChars) correctly copied
input data from the specified offset into internal _charBuffer/_byteBuffer arrays via WriteCharBuffer/WriteByteBuffer,
but then passed the original input arrays (always from index 0) to WideCharToMultiByte/MultiByteToWideChar instead of
the offset-corrected internal buffers. This meant whenever StreamWriter called these methods with a non-zero
character index, wrong data was encoded/decoded.

The fix changes the Win32 API calls to use _charBuffer/_byteBuffer instead of the original arrays, so the correct
offset is always respected.

## Motivation and Context
Users on Chinese (and other non-Latin) Windows systems were unable to read Chinese log output in the BepInEx console —all non-ASCII characters displayed as garbled symbols. This made debugging plugins on Chinese systems extremely
difficult.

Additionally, the ConsoleEncoding offset bug was a latent correctness issue that could cause encoding errors whenever
the .NET StreamWriter or Encoder infrastructure called these methods with a non-zero index.

## How Has This Been Tested?
- Built BepInEx.Core with both .NET Standard 2.0 and .NET 3.5 targets — compiles successfully with 0 errors
- Ran the full Cake build pipeline (dotnet run --project build -- --target MakeDist) — all 13 distribution targets
built successfully, including Unity.IL2CPP-win-x86 (I am an Among Us moderator lol)
- The console codepage fix has been verified on the Unity Mono path, where it was already in use; this change extends
the same behavior to IL2CPP and .NET runtimes
- The ConsoleEncoding buffer fix is self-evidently correct — the internal buffers were always intended to be consumed
by the API calls but were never wired up

## Screenshots (if appropriate):
Before:
<img width="1470" height="767" alt="b1c26282-bc36-4389-a599-0ff43359c52c" src="https://github.com/user-attachments/assets/25806c2c-3e31-4466-b206-8f5550337540" />

Now:
<img width="1470" height="767" alt="af171dcb9e04d6382ecd426272f1de8f" src="https://github.com/user-attachments/assets/2655f99c-b707-43a0-b5a8-354fd4fde375" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.