### PR TITLE
Degrade instead of crashing when the IL2CPP interop assemblies are missing

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/IL2CPPChainloader.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/IL2CPPChainloader.cs
@@ -86,9 +86,7 @@ public class IL2CPPChainloader : BaseChainloader<BasePlugin>
                 // Unhook up front so the detour fires once even if setup below throws.
                 unhook = true;
 
-                // Isolated into its own method so OnInvokeMethod holds no interop type reference of its own: when the
-                // interop assemblies are missing, only this call fails to JIT -- inside the try, so it is caught --
-                // instead of OnInvokeMethod failing to JIT, which throws before the try is entered and crashes the game.
+                // Isolated so a missing-interop JIT failure happens inside the try (caught), not in OnInvokeMethod itself.
                 SetupUnityLogging();
 
                 Il2CppInteropManager.PreloadInteropAssemblies();
@@ -97,7 +95,7 @@ public class IL2CPPChainloader : BaseChainloader<BasePlugin>
             }
             catch (Exception ex)
             {
-                Logger.Log(LogLevel.Fatal, "Unable to execute IL2CPP chainloader -- continuing unmodded so the game still runs.");
+                Logger.Log(LogLevel.Fatal, "Unable to execute IL2CPP chainloader, no plugins will be loaded");
                 Logger.Log(LogLevel.Error, ex);
             }
 
@@ -113,8 +111,7 @@ public class IL2CPPChainloader : BaseChainloader<BasePlugin>
         return result;
     }
 
-    // Holds the interop type references (UnityEngine.Application/LogType) so OnInvokeMethod itself can be JIT-compiled
-    // without the interop assemblies present; this method is JIT-compiled only when called, inside the try above.
+    // JIT-compiled only when called here, so OnInvokeMethod needs no interop assemblies present to JIT.
     private static void SetupUnityLogging()
     {
         if (!ConfigUnityLogging.Value)

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/IL2CPPChainloader.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/IL2CPPChainloader.cs
@@ -83,15 +83,13 @@ public class IL2CPPChainloader : BaseChainloader<BasePlugin>
         if (methodName == "Internal_ActiveSceneChanged")
             try
             {
-                if (ConfigUnityLogging.Value)
-                {
-                    Logger.Sources.Add(new IL2CPPUnityLogSource());
-
-                    Application.CallLogCallback("Test call after applying unity logging hook", "", LogType.Assert,
-                                                true);
-                }
-
+                // Unhook up front so the detour fires once even if setup below throws.
                 unhook = true;
+
+                // Isolated into its own method so OnInvokeMethod holds no interop type reference of its own: when the
+                // interop assemblies are missing, only this call fails to JIT -- inside the try, so it is caught --
+                // instead of OnInvokeMethod failing to JIT, which throws before the try is entered and crashes the game.
+                SetupUnityLogging();
 
                 Il2CppInteropManager.PreloadInteropAssemblies();
 
@@ -99,7 +97,7 @@ public class IL2CPPChainloader : BaseChainloader<BasePlugin>
             }
             catch (Exception ex)
             {
-                Logger.Log(LogLevel.Fatal, "Unable to execute IL2CPP chainloader");
+                Logger.Log(LogLevel.Fatal, "Unable to execute IL2CPP chainloader -- continuing unmodded so the game still runs.");
                 Logger.Log(LogLevel.Error, ex);
             }
 
@@ -113,6 +111,18 @@ public class IL2CPPChainloader : BaseChainloader<BasePlugin>
         }
 
         return result;
+    }
+
+    // Holds the interop type references (UnityEngine.Application/LogType) so OnInvokeMethod itself can be JIT-compiled
+    // without the interop assemblies present; this method is JIT-compiled only when called, inside the try above.
+    private static void SetupUnityLogging()
+    {
+        if (!ConfigUnityLogging.Value)
+            return;
+
+        Logger.Sources.Add(new IL2CPPUnityLogSource());
+
+        Application.CallLogCallback("Test call after applying unity logging hook", "", LogType.Assert, true);
     }
 
     protected override void InitializeLoggers()


### PR DESCRIPTION
When the interop assemblies aren't present at chainloader start, the game crashes silently instead of running unmodded.

`OnInvokeMethod` uses interop types directly in its body -- `Application.CallLogCallback(...)` and `LogType`, both from UnityEngine.CoreModule. That call is inside a try/catch, but it can't catch this: the JIT compiles the whole method before any of it runs, so when the interop assemblies can't be resolved the method throws `FileNotFoundException` at JIT time, before the try is entered. The exception unwinds into the native runtime-invoke detour and the process dies with nothing logged.

This moves the interop call into its own `SetupUnityLogging()` and calls it inside the try. `OnInvokeMethod` no longer references interop, so it JITs without the assemblies; `SetupUnityLogging()` is only JIT-compiled when called (inside the try), so a missing-interop failure is caught and the loader logs it and continues -- the game runs unmodded. I also set `unhook = true` at the top of the try so the detour fires exactly once even if setup throws.

Repro: an IL2CPP game on Unity 6000.0.58 with the interop folder empty. Before, the game CTDs silently right after "Runtime invoke patched". After, it logs `Unable to execute IL2CPP chainloader -- continuing unmodded` and launches. Interop can be missing for ordinary reasons too -- generation failing on an unsupported metadata version, or an incomplete interop folder.

This might also be behind the silent-crash reports in #1188 and #1079 (same OnInvokeMethod path, different Unity builds) -- worth a look from anyone who can still repro those.