### PR TITLE
Do not abort startup when the config file cannot be written

### DIFF
--- a/BepInEx.Core/Configuration/ConfigFile.cs
+++ b/BepInEx.Core/Configuration/ConfigFile.cs
@@ -34,7 +34,7 @@ public class ConfigFile : IDictionary<ConfigDefinition, ConfigEntryBase>
 
         if (File.Exists(ConfigFilePath))
             Reload();
-        else if (saveOnInit) Save();
+        else if (saveOnInit) TrySave();
     }
 
     public static ConfigFile CoreConfig { get; } = new(Paths.BepInExConfigPath, true);
@@ -352,6 +352,24 @@ public class ConfigFile : IDictionary<ConfigDefinition, ConfigEntryBase>
         }
     }
 
+    /// <summary>
+    ///     Writes the config to disk like <see cref="Save" />, but logs and swallows I/O failures (e.g. a read-only
+    ///     or locked config file) instead of throwing. Used for the automatic saves so an unwritable config degrades
+    ///     to the in-memory configuration rather than aborting startup.
+    /// </summary>
+    private void TrySave()
+    {
+        try
+        {
+            Save();
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            Logger.Log(LogLevel.Warning,
+                $"Could not write config file {ConfigFilePath}: {e.Message}. Continuing with the in-memory configuration.");
+        }
+    }
+
     #endregion
 
     #region Wraps
@@ -452,7 +470,7 @@ public class ConfigFile : IDictionary<ConfigDefinition, ConfigEntryBase>
             }
 
             if (SaveOnConfigSet)
-                Save();
+                TrySave();
 
             return entry;
         }
@@ -573,7 +591,7 @@ public class ConfigFile : IDictionary<ConfigDefinition, ConfigEntryBase>
         if (changedEntryBase == null) throw new ArgumentNullException(nameof(changedEntryBase));
 
         if (SaveOnConfigSet)
-            Save();
+            TrySave();
 
         var settingChanged = SettingChanged;
         if (settingChanged == null) return;

--- a/BepInEx.Core/Configuration/ConfigFile.cs
+++ b/BepInEx.Core/Configuration/ConfigFile.cs
@@ -354,8 +354,8 @@ public class ConfigFile : IDictionary<ConfigDefinition, ConfigEntryBase>
 
     /// <summary>
     ///     Writes the config to disk like <see cref="Save" />, but logs and swallows I/O failures (e.g. a read-only
-    ///     or locked config file) instead of throwing. Used for the automatic saves so an unwritable config degrades
-    ///     to the in-memory configuration rather than aborting startup.
+    ///     or locked config file) instead of throwing. Used only for the creation-time saves (initial file write and
+    ///     new-entry binds), which can run before logging is up; explicit saves and setting changes still throw.
     /// </summary>
     private void TrySave()
     {
@@ -591,7 +591,7 @@ public class ConfigFile : IDictionary<ConfigDefinition, ConfigEntryBase>
         if (changedEntryBase == null) throw new ArgumentNullException(nameof(changedEntryBase));
 
         if (SaveOnConfigSet)
-            TrySave();
+            Save();
 
         var settingChanged = SettingChanged;
         if (settingChanged == null) return;


### PR DESCRIPTION
Fixes #1339

`ConfigFile.Save()` opens the file for writing with no exception handling and is invoked automatically via `SaveOnConfigSet` (default `true`) while settings are bound during startup, before logging is initialized. A read-only or otherwise unwritable config file -- a read-only install directory, or a file locked by another process / antivirus -- therefore throws `UnauthorizedAccessException` out of the early startup path and shows the "Failed to start BepInEx" dialog (with no `LogOutput.log`, since logging isn't up yet).

This routes the automatic saves (on init, on bind, on change) through a `TrySave` helper that logs a warning and keeps the in-memory configuration instead of propagating `IOException` / `UnauthorizedAccessException`. Explicit `Save()` calls are unchanged, so a plugin that calls `Save()` directly still sees the exception.

Repro: make `BepInEx/config/BepInEx.cfg` read-only, then launch -- before this change BepInEx fails to start; after it, it logs a warning and continues with the in-memory config.
