### PR TITLE
Allow multiple [TargetType] and [TargetAssembly] attributes

### DIFF
--- a/BepInEx.Preloader.Core/Patching/Attributes.cs
+++ b/BepInEx.Preloader.Core/Patching/Attributes.cs
@@ -82,7 +82,7 @@ public class PatcherPluginInfoAttribute : Attribute
 /// <summary>
 ///     Defines an assembly that a patch method will target.
 /// </summary>
-[AttributeUsage(AttributeTargets.Method)]
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 public class TargetAssemblyAttribute : Attribute
 {
     /// <summary>
@@ -108,7 +108,7 @@ public class TargetAssemblyAttribute : Attribute
 /// <summary>
 ///     Defines a type that a patch method will target.
 /// </summary>
-[AttributeUsage(AttributeTargets.Method)]
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 public class TargetTypeAttribute : Attribute
 {
     /// <param name="targetAssembly">The short filename of the assembly of which <paramref name="targetType" /> belongs to.</param>


### PR DESCRIPTION
### What

`[TargetType]` and `[TargetAssembly]` now allow multiple instances on one patch method.

### Why

The docs say you can specify additional `[TargetType]` attributes to target more types, and the discovery code already reads them with the plural `MetadataHelper.GetAttributes<TargetTypeAttribute>(method)` / `GetAttributes<TargetAssemblyAttribute>(method)` (`AssemblyPatcher.cs`). But both attributes were declared `[AttributeUsage(AttributeTargets.Method)]` without `AllowMultiple = true`, so the C# compiler rejects a second one with **CS0579: Duplicate 'TargetType' attribute** before runtime ever sees it.

Setting `AllowMultiple = true` makes the attribute declarations match both the documentation and the plural consumer. Single-attribute usage is unchanged; this only stops the compiler from rejecting the second attribute.

`[TargetAssembly]` is the sibling attribute consumed the same plural way, so it gets the same fix for consistency.

Fixes #849

Built across net35/net46/net6.
