### PR TITLE
Tolerate SemVer build metadata in plugin versions

### DIFF
--- a/BepInEx.Core/Contract/Attributes.cs
+++ b/BepInEx.Core/Contract/Attributes.cs
@@ -53,7 +53,9 @@ public class BepInPlugin : Attribute
         // no System.Version.TryParse() on .NET 3.5
         try
         {
-            var longVersion = new System.Version(version);
+            // System.Version can't parse a SemVer build-metadata suffix (e.g. 1.2.3.4+sha); drop it first.
+            var plus = version.IndexOf('+');
+            var longVersion = new System.Version(plus >= 0 ? version.Substring(0, plus) : version);
 
             return new Version(longVersion.Major, longVersion.Minor,
                                longVersion.Build != -1 ? longVersion.Build : 0);

--- a/BepInEx.Preloader.Core/Patching/Attributes.cs
+++ b/BepInEx.Preloader.Core/Patching/Attributes.cs
@@ -46,7 +46,9 @@ public class PatcherPluginInfoAttribute : Attribute
         // no System.Version.TryParse() on .NET 3.5
         try
         {
-            var longVersion = new System.Version(version);
+            // System.Version can't parse a SemVer build-metadata suffix (e.g. 1.2.3.4+sha); drop it first.
+            var plus = version.IndexOf('+');
+            var longVersion = new System.Version(plus >= 0 ? version.Substring(0, plus) : version);
 
             return new Version(longVersion.Major, longVersion.Minor,
                                longVersion.Build != -1 ? longVersion.Build : 0);


### PR DESCRIPTION
### What

Plugins whose version carries a SemVer build-metadata suffix (e.g. `9.0.3.2+486c2711...`) now load instead of being silently skipped.

### Why

`IncludeSourceRevisionInInformationalVersion` defaults to `true` in recent MSBuild/VS, which appends `+<commit>` to the informational version. When that string reaches `TryParseLongVersion`:

1. `SemanticVersioning.Version.TryParse` rejects it — the fourth component (`9.0.3.2`) isn't valid SemVer — so it falls through to the `System.Version` path.
2. `new System.Version("9.0.3.2+486c...")` throws on the `+`.
3. The `catch` returns `null`, `metadata.Version` is null, and the plugin is dropped.

The fix strips the build-metadata suffix (everything from `+`) before the `System.Version` parse. Versions without a `+` are untouched, so existing behavior is unchanged.

The same `TryParseLongVersion` exists in two places — `BepInPlugin` (Core) and `PatcherPluginInfo` (Preloader) — so both get the fix.

Fixes #708

Built across net35/net46/net6.
