### PR TITLE
Hash the full UTF-8 byte length in HashStrings

### DIFF
--- a/BepInEx.Core/Utility.cs
+++ b/BepInEx.Core/Utility.cs
@@ -331,7 +331,10 @@ public static class Utility
         using var md5 = MD5.Create();
 
         foreach (var str in strings)
-            md5.TransformBlock(Encoding.UTF8.GetBytes(str), 0, str.Length, null, 0);
+        {
+            var bytes = Encoding.UTF8.GetBytes(str);
+            md5.TransformBlock(bytes, 0, bytes.Length, null, 0);
+        }
 
         md5.TransformFinalBlock(new byte[0], 0, 0);
 


### PR DESCRIPTION
### What

`HashStrings` hashed only `str.Length` bytes of each string's UTF-8 encoding, so for any non-ASCII input the digest covered only a truncated byte prefix.

### Fix

Capture the encoded byte array and pass `bytes.Length` (not `str.Length`) as the `TransformBlock` count.

Fixes #1354

Built across net35/net46/net6.
