### PR TITLE
Enumerate a config snapshot under the lock

### DIFF
--- a/BepInEx.Core/Configuration/ConfigFile.cs
+++ b/BepInEx.Core/Configuration/ConfigFile.cs
@@ -92,9 +92,12 @@ public class ConfigFile : IDictionary<ConfigDefinition, ConfigEntryBase>
     public ConfigEntryBase this[string section, string key] => this[new ConfigDefinition(section, key)];
 
     /// <inheritdoc />
-    public IEnumerator<KeyValuePair<ConfigDefinition, ConfigEntryBase>> GetEnumerator() =>
-        // We can't really do a read lock for this
-        Entries.GetEnumerator();
+    public IEnumerator<KeyValuePair<ConfigDefinition, ConfigEntryBase>> GetEnumerator()
+    {
+        // Enumerate a snapshot taken under the lock so a concurrent mutation cannot invalidate the iterator.
+        lock (_ioLock)
+            return Entries.ToList().GetEnumerator();
+    }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 


### PR DESCRIPTION
### What

`GetEnumerator()` returned the live `Entries` dictionary enumerator with no lock, despite the class documenting all public methods as thread-safe — a concurrent `Bind`/`Reload` could invalidate it mid-iteration.

### Fix

Snapshot `Entries` under `_ioLock` before enumerating (matching the snapshot approach the logging collections already use).

Fixes #1356

Built across net35/net46/net6.
