### PR TITLE
Remove the duplicate byte TomlTypeConverter registration

### DIFF
--- a/BepInEx.Core/Configuration/TomlTypeConverter.cs
+++ b/BepInEx.Core/Configuration/TomlTypeConverter.cs
@@ -31,11 +31,6 @@ public static class TomlTypeConverter
             ConvertToString = (obj, type) => obj.ToString().ToLowerInvariant(),
             ConvertToObject = (str, type) => bool.Parse(str)
         },
-        [typeof(byte)] = new TypeConverter
-        {
-            ConvertToString = (obj, type) => obj.ToString(),
-            ConvertToObject = (str, type) => byte.Parse(str)
-        },
 
         //integral types
 


### PR DESCRIPTION
### What

`typeof(byte)` was registered twice in the `TomlTypeConverter.TypeConverters` initializer; the second entry silently overwrote the first (both identical), leaving a dead registration.

### Fix

Remove the stray earlier `byte` entry, keeping the one grouped with the other integral types.

Fixes #1358

Built across net35/net46/net6.
