### PR TITLE
Follow PE export jmp thunks before applying a native detour

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Hook/INativeDetour.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Hook/INativeDetour.cs
@@ -73,7 +73,7 @@ public interface INativeDetour : IDetour
 
             if (op == 0xFF && Marshal.ReadByte(fn + 1) == 0x25)
             {
-                if (nint.Size == 8)
+                if (IntPtr.Size == 8)
                     fn = Marshal.ReadIntPtr(fn + 6 + Marshal.ReadInt32(fn + 2));
                 else
                     fn = Marshal.ReadIntPtr((nint)(uint)Marshal.ReadInt32(fn + 2));

--- a/Runtimes/Unity/BepInEx.Unity.IL2CPP/Hook/INativeDetour.cs
+++ b/Runtimes/Unity/BepInEx.Unity.IL2CPP/Hook/INativeDetour.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using BepInEx.Configuration;
+using BepInEx.Logging;
 using BepInEx.Unity.IL2CPP.Hook.Dobby;
 using BepInEx.Unity.IL2CPP.Hook.Funchook;
 using MonoMod.RuntimeDetour;
@@ -17,6 +19,8 @@ public interface INativeDetour : IDetour
          "The native provider to use for managed detours"
         );
 
+    private static readonly ManualLogSource ThunkLog = Logger.CreateLogSource("NativeDetour");
+
     public nint OriginalMethodPtr { get; }
     public nint DetourMethodPtr { get; }
     public nint TrampolinePtr { get; }
@@ -27,6 +31,11 @@ public interface INativeDetour : IDetour
 
     public static INativeDetour Create<T>(nint original, T target) where T : Delegate
     {
+        var resolved = FollowExportThunks(original);
+        if (resolved != original)
+            ThunkLog.LogDebug($"Resolved export thunk 0x{original:X} -> 0x{resolved:X}");
+        original = resolved;
+
         var detour = DetourProviderType.Value switch
         {
             DetourProvider.Dobby    => new DobbyDetour(original, target),
@@ -39,6 +48,42 @@ public interface INativeDetour : IDetour
         }
 
         return detour;
+    }
+
+    /// <summary>
+    /// PE exports are often a <c>jmp rel32</c> (or <c>jmp [rip+disp]</c>) stub with int3 padding.
+    /// Dobby aborts if asked to patch that stub. Follow to the real prologue first.
+    /// No-op when the pointer is already a function body.
+    /// </summary>
+    private static nint FollowExportThunks(nint func)
+    {
+        if (func == 0) return func;
+        var fn = func;
+        for (var hops = 0; hops < 8; hops++)
+        {
+            byte op;
+            try { op = Marshal.ReadByte(fn); }
+            catch { return fn; }
+
+            if (op == 0xE9)
+            {
+                fn += 5 + Marshal.ReadInt32(fn + 1);
+                continue;
+            }
+
+            if (op == 0xFF && Marshal.ReadByte(fn + 1) == 0x25)
+            {
+                if (nint.Size == 8)
+                    fn = Marshal.ReadIntPtr(fn + 6 + Marshal.ReadInt32(fn + 2));
+                else
+                    fn = Marshal.ReadIntPtr((nint)(uint)Marshal.ReadInt32(fn + 2));
+                continue;
+            }
+
+            break;
+        }
+
+        return fn;
     }
 
     public static INativeDetour CreateAndApply<T>(nint from, T to, out T original)


### PR DESCRIPTION
## Summary
- `IL2CPPChainloader` patches `il2cpp_runtime_invoke` from `GetProcAddress`. On some Unity 6 IL2CPP builds that export is a `jmp rel32` stub (`int3` padding), not the prologue.
- Dobby aborting on that stub is the same class as [#1188](https://github.com/BepInEx/BepInEx/issues/1188) (dies after `Runtime invoke patched`).
- Resolve `E9` and `FF 25` in `INativeDetour.Create` so **Default/Dobby and Funchook** all patch the real body. No-op when the pointer is already a function.

## Test plan
- [ ] Unity IL2CPP where `il2cpp_runtime_invoke` is an `E9` stub: `DetourProviderType = Default` (Dobby) gets past `Runtime invoke patched` with empty `plugins/`.
- [ ] Games whose export is already the prologue: no behavior change.
- [ ] Funchook provider still works (thunk already followed here).

Runtime-tested the stub dump on Unity `6000.3.15x1` (`GameAssembly.dll` export RVA `0x87BBE0` → body). Empty-plugins Dobby re-test after this patch is the remaining check.
