### PR TITLE
Don't kill the chainloader when Unity log callbacks are stripped

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.Mono/Logging/UnityLogSource.cs
+++ b/Runtimes/Unity/BepInEx.Unity.Mono/Logging/UnityLogSource.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using BepInEx.Logging;
 using UnityEngine;
+using Logger = BepInEx.Logging.Logger;
 
 namespace BepInEx.Unity.Mono.Logging;
 
@@ -61,6 +62,23 @@ public class UnityLogSource : ILogSource
         {
             var registerLogCallback =
                 typeof(Application).GetMethod("RegisterLogCallback", BindingFlags.Public | BindingFlags.Static);
+
+            // Unity's managed code stripper can remove both Application.logMessageReceived and the
+            // legacy Application.RegisterLogCallback. Invoking a null MethodInfo here throws a
+            // NullReferenceException out of this static constructor, which propagates through
+            // Chainloader.Initialize and silently prevents the chainloader (and therefore every
+            // plugin) from starting. Unity log forwarding is optional, so degrade instead of
+            // taking the whole loader down with us.
+            if (registerLogCallback == null)
+            {
+                Logger.Log(LogLevel.Warning,
+                           "Unity log forwarding is unavailable: neither " +
+                           "Application.logMessageReceived nor Application.RegisterLogCallback exist " +
+                           "in this build (they were most likely stripped). Unity log messages will " +
+                           "not appear in the BepInEx log.");
+                return;
+            }
+
             registerLogCallback.Invoke(null, new object[] { callback });
             //UnsubscribeAction = () => registerLogCallback.Invoke(null, new object[] { null });
         }


### PR DESCRIPTION
## Description

`UnityLogSource`'s static constructor subscribes to `Application.logMessageReceived`, falling back to the legacy `Application.RegisterLogCallback` when that event is missing:

```csharp
var registerLogCallback =
    typeof(Application).GetMethod("RegisterLogCallback", BindingFlags.Public | BindingFlags.Static);
registerLogCallback.Invoke(null, new object[] { callback });
```

Unity''s managed code stripper can remove **both** members. `GetMethod` then returns `null`, and the unguarded `Invoke` throws a `NullReferenceException` out of the static constructor.

This change guards the null and logs a warning instead, so Unity log forwarding degrades on its own rather than taking the loader down.

## Motivation and Context

Because the static constructor runs from chainloader initialisation, that `NullReferenceException` propagates up through the entrypoint''s `.cctor` and **the chainloader never starts — no plugins load at all**.

On the 5.x line, where I originally hit this, the failure is close to undiagnosable:

- `LogOutput.log` ends cleanly at `Preloader finished`, with no error.
- `BepInEx/cache/` stays empty, so it looks like plugins were never scanned.
- The exception appears **only on stdout**, which most users never capture.
- The game itself runs completely normally.

Captured stack trace (Beacon Pines, Unity 2021.3.45f1, Mono, BepInEx 5.4.23.5):

```
NullReferenceException: Object reference not set to an instance of an object
  at BepInEx.Logging.UnityLogSource..cctor ()
Rethrow as TypeInitializationException: The type initializer for ''BepInEx.Logging.UnityLogSource'' threw an exception.
  at BepInEx.Bootstrap.Chainloader.Initialize (System.String gameExePath, System.Boolean startConsole, ...)
  at UnityEngine.MonoBehaviour..cctor ()
```

Confirmed against that game''s `UnityEngine.CoreModule.dll` with Cecil:

```
Application events: [''onBeforeRender'', ''focusChanged'', ''quitting'']
has logMessageReceived event: False
has RegisterLogCallback method: False
```

Setting `UnityLogListening = false` works around it, but only once you already know that is the cause.

## How Has This Been Tested?

- `BepInEx.Unity.Mono` builds clean for both target frameworks (`net35` and `netstandard2.0`).
- Reproduced and fixed on a real game: Beacon Pines (Unity 2021.3.45f1, Mono, x64), whose `Application` has neither `logMessageReceived` nor `RegisterLogCallback`.
- **Verified on `master`.** This is reachable there once #1391 is applied — without it, `InitializeLoggers` fails eight lines earlier on the also-stripped `Application.unityVersion`, which masks this crash. With #1391 but *not* this PR:

  ```
  [Fatal] Unable to complete chainloader init: The type initializer for 'BepInEx.Unity.Mono.Logging.UnityLogSource' threw an exception.
    at BepInEx.Unity.Mono.Bootstrap.UnityChainloader.InitializeLoggers () ... UnityChainloader.cs:170
  ```

  With both applied, the same game starts cleanly and a test plugin's `Awake` runs:

  ```
  [Warning:   BepInEx] Unity log forwarding is unavailable: neither Application.logMessageReceived nor Application.RegisterLogCallback exist in this build ...
  [Message:   BepInEx] Chainloader initialized
  [Info   :   BepInEx] Loading [Probe6 1.0.0]
  [Message:    Probe6] PROBE6 AWAKE
  [Message:   BepInEx] Chainloader startup complete
  ```

- Also independently reproduced on the 5.x line, where it silently prevented the chainloader from starting; backported in #1392.
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

