### PR TITLE
Survive stripped UnityEngine.Application members during chainloader init

### DIFF
--- a/Runtimes/Unity/BepInEx.Unity.Mono/Bootstrap/UnityChainloader.cs
+++ b/Runtimes/Unity/BepInEx.Unity.Mono/Bootstrap/UnityChainloader.cs
@@ -60,6 +60,26 @@ public class UnityChainloader : BaseChainloader<BaseUnityPlugin>
         get => Application.unityVersion;
     }
 
+    /// <summary>
+    ///     Reads the runtime Unity version, returning null if it is unavailable.
+    ///     Unity's managed code stripper can remove Application.unityVersion entirely, in which case
+    ///     touching it throws MissingMethodException. The version is only used for an informational
+    ///     log line, so it must not be able to abort chainloader initialisation.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static string TryGetUnityVersion()
+    {
+        try
+        {
+            return UnityVersion;
+        }
+        catch (Exception e)
+        {
+            Logger.Log(LogLevel.Debug, $"Could not read the runtime Unity version: {e.Message}");
+            return null;
+        }
+    }
+
     [Obsolete("This method is public due to a limitation with Unity 4.x. DO NOT CALL", true)]
     public static void StaticStart(string gameExePath = null)
     {
@@ -116,6 +136,12 @@ public class UnityChainloader : BaseChainloader<BaseUnityPlugin>
         {
             Logger.Log(LogLevel.Fatal, $"Unable to complete chainloader init: {ex.Message}");
             Logger.Log(LogLevel.Fatal, ex.StackTrace);
+
+            // Rethrow so callers do not go on to Execute() a chainloader that was never
+            // initialised. Swallowing here produces a far worse failure mode than crashing:
+            // the loader carries on to log "Chainloader startup complete" while every plugin
+            // silently never runs, which is extremely hard to diagnose.
+            throw;
         }
     }
 
@@ -125,11 +151,16 @@ public class UnityChainloader : BaseChainloader<BaseUnityPlugin>
 
         Logger.Listeners.Add(new UnityLogListener());
 
-        // Update version info from runtime in case it wasn't set yet
-        var prevVersion = UnityInfo.Version;
-        UnityInfo.SetRuntimeUnityVersion(UnityVersion);
-        if (UnityInfo.Version != prevVersion)
-            Logger.Log(LogLevel.Info, $"UnityPlayer version: {UnityInfo.Version}");
+        // Update version info from runtime in case it wasn't set yet.
+        // May be unavailable on aggressively stripped builds; it is informational only.
+        var runtimeUnityVersion = TryGetUnityVersion();
+        if (runtimeUnityVersion != null)
+        {
+            var prevVersion = UnityInfo.Version;
+            UnityInfo.SetRuntimeUnityVersion(runtimeUnityVersion);
+            if (UnityInfo.Version != prevVersion)
+                Logger.Log(LogLevel.Info, $"UnityPlayer version: {UnityInfo.Version}");
+        }
 
         if (!ConfigDiskWriteUnityLog.Value) DiskLogListener.BlacklistedSources.Add("Unity Log");
 


### PR DESCRIPTION
## Description

Two related failures when `UnityEngine.Application` has been aggressively stripped:

1. `InitializeLoggers` reads `Application.unityVersion` (line 130). The managed code stripper can remove it, and the resulting `MissingMethodException` aborts the rest of chainloader initialisation — including `Logger.Sources.Add(new UnityLogSource())` eight lines later. The version is only used for an informational log line, so it is now read defensively.

2. `UnityChainloader.Initialize` caught every exception, logged it as `Fatal`, and returned normally. `StaticStart` then called `Execute()` on a chainloader that was never initialised, so BepInEx logged **`Chainloader startup complete` while every plugin silently never ran**. Init failures now propagate.

## Motivation and Context

Observed on Beacon Pines (Unity 2021.3.45f1, Mono, x64), whose `Application` is missing `unityVersion`, `logMessageReceived` and `RegisterLogCallback`.

Unpatched `master`:

```
[Fatal  :   BepInEx] Unable to complete chainloader init: Method not found: string UnityEngine.Application.get_unityVersion()
  at BepInEx.Unity.Mono.Bootstrap.UnityChainloader.InitializeLoggers () ... UnityChainloader.cs:130
[Info   :   BepInEx] 1 plugin to load
[Info   :   BepInEx] Loading [Probe6 1.0.0]
[Message:   BepInEx] Chainloader startup complete
```

Note the last three lines: the loader reports success after a fatal error. A test plugin that writes a file from `Awake` never wrote it.

Fixes #1390.

## How Has This Been Tested?

Built the `Unity.Mono-win-x64` distribution from this branch and ran it against that game.

- **Before:** init aborted at `UnityChainloader.cs:130`; `Chainloader initialized` never logged.
- **After:** init proceeds past the version read and reaches `Chainloader initialized`.

With this fix alone, execution then advances to the *next* stripped-member failure at line 170 (`UnityLogSource`'s type initializer) — which is what #1389 guards:

```
[Fatal] Unable to complete chainloader init: The type initializer for 'BepInEx.Unity.Mono.Logging.UnityLogSource' threw an exception.
  at ... UnityChainloader.InitializeLoggers () ... UnityChainloader.cs:170
```

Applying both this PR and #1389 gets that game to a clean startup:

```
[Warning:   BepInEx] Unity log forwarding is unavailable: neither Application.logMessageReceived nor Application.RegisterLogCallback exist in this build ...
[Message:   BepInEx] Chainloader initialized
[Info   :   BepInEx] 1 plugin to load
[Info   :   BepInEx] Loading [Probe6 1.0.0]
[Message:   BepInEx] Chainloader startup complete
```

With both fixes applied, a test plugin's `Awake` runs correctly on that game:

```
[Message:   BepInEx] Chainloader initialized
[Info   :   BepInEx] 1 plugin to load
[Info   :   BepInEx] Loading [Probe6 1.0.0]
[Message:    Probe6] PROBE6 AWAKE
[Message:   BepInEx] Chainloader startup complete
```
Builds clean for `net35` and `netstandard2.0`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

