### PR TITLE
v5: Don't kill the chainloader when Unity log callbacks are stripped

### DIFF
--- a/BepInEx/Logging/UnityLogSource.cs
+++ b/BepInEx/Logging/UnityLogSource.cs
@@ -59,6 +59,20 @@ namespace BepInEx.Logging
 			else
 			{
 				MethodInfo registerLogCallback = typeof(Application).GetMethod("RegisterLogCallback", BindingFlags.Public | BindingFlags.Static);
+
+				// Unity's managed code stripper can remove both Application.logMessageReceived and the
+				// legacy Application.RegisterLogCallback. Invoking a null MethodInfo here throws out of
+				// this static constructor, which propagates through Chainloader.Initialize and silently
+				// prevents the chainloader (and therefore every plugin) from starting. Unity log
+				// forwarding is optional, so degrade instead of taking the whole loader down.
+				if (registerLogCallback == null)
+				{
+					Logger.LogWarning("Unity log forwarding is unavailable: neither Application.logMessageReceived " +
+					                  "nor Application.RegisterLogCallback exist in this build (they were most likely " +
+					                  "stripped). Unity log messages will not appear in the BepInEx log.");
+					return;
+				}
+
 				registerLogCallback.Invoke(null, new object[] { callback });
 				//UnsubscribeAction = () => registerLogCallback.Invoke(null, new object[] { null });
 			}


### PR DESCRIPTION
## Description

Backport of #1389 to `v5-lts`.

`UnityLogSource`'s static constructor subscribes to `Application.logMessageReceived`, falling back to the legacy `Application.RegisterLogCallback` when that event is missing:

```csharp
MethodInfo registerLogCallback = typeof(Application).GetMethod("RegisterLogCallback", BindingFlags.Public | BindingFlags.Static);
registerLogCallback.Invoke(null, new object[] { callback });
```

Unity''s managed code stripper can remove **both** members. `GetMethod` then returns `null`, and the unguarded `Invoke` throws a `NullReferenceException` out of the static constructor.

## Motivation and Context

Because the static constructor runs from `Chainloader.Initialize`, that exception propagates up through the entrypoint''s `.cctor` and **the chainloader never starts — no plugins load at all**.

The failure is close to undiagnosable in practice:

- `LogOutput.log` ends cleanly at `Preloader finished`, with no error.
- `BepInEx/cache/` stays empty, so it looks like plugins were never scanned.
- The exception appears **only on stdout**, which most users never capture.
- The game itself runs completely normally.

Captured on Beacon Pines (Unity 2021.3.45f1, Mono, x64) with BepInEx 5.4.23.5:

```
NullReferenceException: Object reference not set to an instance of an object
  at BepInEx.Logging.UnityLogSource..cctor ()
Rethrow as TypeInitializationException: The type initializer for ''BepInEx.Logging.UnityLogSource'' threw an exception.
  at BepInEx.Bootstrap.Chainloader.Initialize (System.String gameExePath, System.Boolean startConsole, ...)
  at UnityEngine.MonoBehaviour..cctor ()
```

That game''s `UnityEngine.Application` has neither member:

```
Application events: [''onBeforeRender'', ''focusChanged'', ''quitting'']
has logMessageReceived event: False
has RegisterLogCallback method: False
```

Setting `UnityLogListening = false` works around it, but only once you already know that is the cause.

This is filed separately from #1389 because the file has moved and been restyled on `master` (`Runtimes/Unity/BepInEx.Unity.Mono/Logging/`, file-scoped namespaces, spaces), so the same diff does not apply to both branches.

## How Has This Been Tested?

Verified against the **official 5.4.23.5 release**, not a from-source build: installed the published `BepInEx_win_x64_5.4.23.5.zip` into the affected game (Beacon Pines, Unity 2021.3.45f1, Mono, x64) and replaced only `BepInEx/core/BepInEx.dll` with one built from this branch. `UnityLogListening` was left at its default `true` throughout — the setting that triggers the crash.

**Before (stock release DLL):** the log stops dead at `Preloader finished`, and the exception appears only on stdout:

```
NullReferenceException: Object reference not set to an instance of an object
  at BepInEx.Logging.UnityLogSource..cctor ()
Rethrow as TypeInitializationException: The type initializer for 'BepInEx.Logging.UnityLogSource' threw an exception.
```

No chainloader, no plugins, nothing in `LogOutput.log` to indicate a problem.

**After (this branch''s DLL):**

```
[Message:   BepInEx] Preloader finished
[Warning:   BepInEx] Unity log forwarding is unavailable: neither Application.logMessageReceived nor Application.RegisterLogCallback exist in this build (they were most likely stripped). Unity log messages will not appear in the BepInEx log.
[Message:   BepInEx] Chainloader ready
[Message:   BepInEx] Chainloader started
[Info   :   BepInEx] 1 plugin to load
[Info   :   BepInEx] Loading [Beacon Pines Access 0.1.0]
[Message:   BepInEx] Chainloader startup complete
```

The plugin loads and runs, and the `UnityLogListening = false` workaround is no longer needed.

`BepInEx.csproj` builds clean on this branch.

### Note

This game additionally needs a non-default `[Preloader.Entrypoint]` before plugins are actually ticked — filed separately as #1393. That is independent of this fix; both are required to get a working plugin on this title.
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.




