### PR TITLE
v5: Default the entrypoint to MonoBehaviour

### DIFF
--- a/BepInEx.Preloader/Preloader.cs
+++ b/BepInEx.Preloader/Preloader.cs
@@ -289,7 +289,7 @@ namespace BepInEx.Preloader
 
 		private static readonly ConfigEntry<string> ConfigEntrypointType = ConfigFile.CoreConfig.Bind(
 			"Preloader.Entrypoint", "Type",
-			"Application",
+			"MonoBehaviour",
 			"The name of the type in the entrypoint assembly to search for the entrypoint method.");
 
 		private static readonly ConfigEntry<string> ConfigEntrypointMethod = ConfigFile.CoreConfig.Bind(


### PR DESCRIPTION
## Description

Changes the default `[Preloader.Entrypoint]` `Type` from `Application` to `MonoBehaviour` on 5.x. One-line change.

## Motivation and Context

Fixes #1393.

On some Unity Mono games, `Application..cctor` runs before Unity is ready to register the `BepInEx_Manager` GameObject with the update loop. The result is that plugins load and appear completely healthy — `Awake` and `OnEnable` run, Harmony patches apply, `Chainloader startup complete` is logged — but `Update`, `LateUpdate` and coroutines **never fire**, so any per-frame plugin logic is silently dead.

From inside `OnEnable` the component state looks entirely normal:

```
isActiveAndEnabled=True  go=BepInEx_Manager  goActive=True  hideFlags=None  timeScale=1
```

`Awake`/`OnEnable` still run because Unity executes those synchronously during `AddComponent`, which is what makes this so hard to diagnose — there is nothing in the log to search for.

`MonoBehaviour..cctor` runs late enough to avoid the problem, and is **already the default in BepInEx 6**, so this also aligns the two branches.

### Compatibility

Existing installs are unaffected. `ConfigFile` writes `BepInEx.cfg` on first run, so any existing installation already has an explicit `Type = Application` on disk and keeps it. Only fresh installs pick up the new default.

Confirmed in `ConfigFile.Bind`: a key already present in the file is restored from `OrphanedEntries` via `SetSerializedValue`, so the new default only applies when the key is absent.

However, this *is* a change of shipped behaviour for **new** installs, so I have ticked "breaking change" as well — see the caveat under testing.

### Relationship to the existing docs

The published troubleshooting guide already recommends `Type = MonoBehaviour` for Unity 2017 and newer (and `MonoBehaviour` or `Camera` for Unity 5 and older). It does not mention `Application` at all. This change simply makes the shipped default match that existing guidance, so no documentation update should be needed.

## How Has This Been Tested?

- `BepInEx.Preloader` builds clean on this branch.
- The value itself is verified in normal use, not just in theory: my install of the affected game (Beacon Pines, Unity 2021.3.45f1, Mono, x64) has been running on the official 5.4.23.5 release with `Type = MonoBehaviour` set manually, and a screen-reader plugin that depends entirely on `Update()` works correctly. With the shipped default of `Application`, the same plugin loads, logs a clean startup, and never ticks once.

  Confirmed with a heartbeat in `Update()`, and independently with a `File.WriteAllText` that bypasses BepInEx logging entirely, in case the logger itself were at fault. Before the change the file was never written; after it, `Update() is running` and the plugin behaves normally.

**Caveat worth a maintainer's judgement:** I have tested this on exactly one game. If any title depends on the earlier Application..cctor timing, a fresh install would newly break on it, and I have no evidence either way. That risk is the main reason to consider this carefully rather than take my word for it.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — for **new** installs only; see Compatibility

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



